### PR TITLE
Fix `Minitest/TestMethodName` for tests with multiple assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#118](https://github.com/rubocop/rubocop-minitest/pull/118): **(BREAKING)** Fix `Minitest/AssertEmptyLiteral` by making it check for `assert_equal([], array)` instead of `assert([], array)`. ([@cstyles][])
+* [#122](https://github.com/rubocop/rubocop-minitest/pull/122): Fix `Minitest/TestMethodName` for tests with multiple assertions. ([@ghiculescu][])
 
 ## 0.10.3 (2021-01-12)
 
@@ -182,3 +183,4 @@
 [@fatkodima]: https://github.com/fatkodima
 [@tsmmark]: https://github.com/tsmmark
 [@cstyles]: https://github.com/cstyles
+[@ghiculescu]: https://github.com/ghiculescu

--- a/lib/rubocop/cop/minitest/test_method_name.rb
+++ b/lib/rubocop/cop/minitest/test_method_name.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def offense?(node)
-          return false if node.each_child_node(:send).none? { |send_node| assertion_method?(send_node.method_name) }
+          return false if assertions(node).none?
 
           public?(node) && node.arguments.empty? && !test_method_name?(node) && !lifecycle_hook_method?(node)
         end

--- a/test/rubocop/cop/minitest/test_method_name_test.rb
+++ b/test/rubocop/cop/minitest/test_method_name_test.rb
@@ -30,6 +30,37 @@ class TestMethodNameTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_test_method_without_prefix_with_multiple_assertions
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(expected, actual)
+          assert_equal expected, actual
+        end
+
+        def do_something_else
+            ^^^^^^^^^^^^^^^^^ Test method name should start with `test_` prefix.
+          assert_equal(expected, actual)
+          assert_equal expected, actual
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(expected, actual)
+          assert_equal expected, actual
+        end
+
+        def test_do_something_else
+          assert_equal(expected, actual)
+          assert_equal expected, actual
+        end
+      end
+    RUBY
+  end
+
   def test_checks_only_test_classes
     assert_no_offenses(<<~RUBY)
       class FooTest


### PR DESCRIPTION
Currently it only works for tests with a single assertion.