### PR TITLE
Require RuboCop 0.90 or higher due to use `RESTRICT_ON_SEND`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * [#118](https://github.com/rubocop/rubocop-minitest/pull/118): **(BREAKING)** Fix `Minitest/AssertEmptyLiteral` by making it check for `assert_equal([], array)` instead of `assert([], array)`. ([@cstyles][])
+* [#125](https://github.com/rubocop/rubocop-minitest/pull/125): Require RuboCop 0.90 or higher. ([@koic][])
 
 ## 0.10.3 (2021-01-12)
 

--- a/lib/rubocop/cop/minitest/assert_empty_literal.rb
+++ b/lib/rubocop/cop/minitest/assert_empty_literal.rb
@@ -19,6 +19,7 @@ module RuboCop
 
         MSG = 'Prefer using `assert_empty(%<arguments>s)` over ' \
               '`assert_equal(%<literal>s, %<arguments>s)`.'
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         def_node_matcher :assert_equal_with_empty_literal, <<~PATTERN
           (send nil? :assert_equal ${hash array} $...)

--- a/lib/rubocop/cop/minitest/assert_in_delta.rb
+++ b/lib/rubocop/cop/minitest/assert_in_delta.rb
@@ -18,6 +18,8 @@ module RuboCop
       class AssertInDelta < Cop
         include InDeltaMixin
 
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
+
         def_node_matcher :equal_floats_call, <<~PATTERN
           (send nil? :assert_equal $_ $_ $...)
         PATTERN

--- a/lib/rubocop/cop/minitest/assert_nil.rb
+++ b/lib/rubocop/cop/minitest/assert_nil.rb
@@ -20,6 +20,7 @@ module RuboCop
 
         MSG = 'Prefer using `assert_nil(%<arguments>s)` over ' \
               '`assert_equal(nil, %<arguments>s)`.'
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         def_node_matcher :assert_equal_with_nil, <<~PATTERN
           (send nil? :assert_equal nil $_ $...)

--- a/lib/rubocop/cop/minitest/assert_path_exists.rb
+++ b/lib/rubocop/cop/minitest/assert_path_exists.rb
@@ -17,6 +17,7 @@ module RuboCop
       #
       class AssertPathExists < Cop
         MSG = 'Prefer using `%<good_method>s` over `%<bad_method>s`.'
+        RESTRICT_ON_SEND = %i[assert].freeze
 
         def_node_matcher :assert_file_exists, <<~PATTERN
           (send nil? :assert

--- a/lib/rubocop/cop/minitest/assert_truthy.rb
+++ b/lib/rubocop/cop/minitest/assert_truthy.rb
@@ -20,6 +20,7 @@ module RuboCop
 
         MSG = 'Prefer using `assert(%<arguments>s)` over ' \
               '`assert_equal(true, %<arguments>s)`.'
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         def_node_matcher :assert_equal_with_truthy, <<~PATTERN
           (send nil? :assert_equal true $_ $...)

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -30,6 +30,8 @@ module RuboCop
 
         BLOCK_MATCHERS = %i[must_output must_raise must_be_silent must_throw].freeze
 
+        RESTRICT_ON_SEND = VALUE_MATCHERS + BLOCK_MATCHERS
+
         VALUE_MATCHERS_STR = VALUE_MATCHERS.map do |m|
           ":#{m}"
         end.join(' ').freeze

--- a/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
+++ b/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
@@ -21,6 +21,7 @@ module RuboCop
         include ArgumentRangeHelper
 
         MSG = 'Replace the literal with the first argument.'
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         def on_send(node)
           return unless node.method?(:assert_equal)

--- a/lib/rubocop/cop/minitest/refute_equal.rb
+++ b/lib/rubocop/cop/minitest/refute_equal.rb
@@ -19,6 +19,7 @@ module RuboCop
 
         MSG = 'Prefer using `refute_equal(%<preferred>s)` over ' \
               '`assert(%<over>s)`.'
+        RESTRICT_ON_SEND = %i[assert].freeze
 
         def_node_matcher :assert_not_equal, <<~PATTERN
           (send nil? :assert ${(send $_ :!= $_) (send (send $_ :! ) :== $_) } $... )

--- a/lib/rubocop/cop/minitest/refute_false.rb
+++ b/lib/rubocop/cop/minitest/refute_false.rb
@@ -25,6 +25,7 @@ module RuboCop
               '`assert_equal(false, %<arguments>s)`.'
         MSG_FOR_ASSERT = 'Prefer using `refute(%<arguments>s)` over ' \
               '`assert(!%<arguments>s)`.'
+        RESTRICT_ON_SEND = %i[assert_equal assert].freeze
 
         def_node_matcher :assert_equal_with_false, <<~PATTERN
           (send nil? :assert_equal false $_ $...)

--- a/lib/rubocop/cop/minitest/refute_in_delta.rb
+++ b/lib/rubocop/cop/minitest/refute_in_delta.rb
@@ -18,6 +18,8 @@ module RuboCop
       class RefuteInDelta < Cop
         include InDeltaMixin
 
+        RESTRICT_ON_SEND = %i[refute_equal].freeze
+
         def_node_matcher :equal_floats_call, <<~PATTERN
           (send nil? :refute_equal $_ $_ $...)
         PATTERN

--- a/lib/rubocop/cop/minitest/refute_nil.rb
+++ b/lib/rubocop/cop/minitest/refute_nil.rb
@@ -20,6 +20,7 @@ module RuboCop
 
         MSG = 'Prefer using `refute_nil(%<arguments>s)` over ' \
               '`refute_equal(nil, %<arguments>s)`.'
+        RESTRICT_ON_SEND = %i[refute_equal].freeze
 
         def_node_matcher :refute_equal_with_nil, <<~PATTERN
           (send nil? :refute_equal nil $_ $...)

--- a/lib/rubocop/cop/minitest/refute_path_exists.rb
+++ b/lib/rubocop/cop/minitest/refute_path_exists.rb
@@ -17,6 +17,7 @@ module RuboCop
       #
       class RefutePathExists < Cop
         MSG = 'Prefer using `%<good_method>s` over `%<bad_method>s`.'
+        RESTRICT_ON_SEND = %i[refute].freeze
 
         def_node_matcher :refute_file_exists, <<~PATTERN
           (send nil? :refute

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -29,6 +29,7 @@ module RuboCop
 
           MSG = 'Prefer using `#{preferred_method}(%<new_arguments>s)` over ' \
                 '`#{assertion_method}(%<original_arguments>s)`.'
+          RESTRICT_ON_SEND = %i[#{assertion_method}].freeze
 
           def on_send(node)
             return unless node.method?(:#{assertion_method})

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.87', '< 2.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.90', '< 2.0'
   spec.add_development_dependency 'minitest', '~> 5.11'
 end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8365

This PR uses `RESTRICT_ON_SEND` to restrict callbacks `on_send` to specific method names only.
`RESTRICT_ON_SEND` has been introduced since RuboCop 0.90.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
