### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.4
-          image: circleci/ruby:2.4
-      - rake_default:
           name: Ruby 2.5
           image: circleci/ruby:2.5
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#129](https://github.com/rubocop/rubocop-minitest/pull/129): Drop Ruby 2.4 support. ([@koic][])
+
 ## 0.11.1 (2021-03-31)
 
 ### Changes

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.license = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
   spec.metadata = {
     'homepage_uri' => 'https://docs.rubocop.org/rubocop-minitest/',
     'changelog_uri' => 'https://github.com/rubocop/rubocop-minitest/blob/master/CHANGELOG.md',

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -46,17 +46,15 @@ task documentation_syntax_check: :yard_for_generate_documentation do
     end
 
     examples.to_a.each do |example|
-      begin
-        buffer = Parser::Source::Buffer.new('<code>', 1)
-        buffer.source = example.text
-        parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
-        parser.diagnostics.all_errors_are_fatal = true
-        parser.parse(buffer)
-      rescue Parser::SyntaxError => e
-        path = example.object.file
-        puts "#{path}: Syntax Error in an example. #{e}"
-        ok = false
-      end
+      buffer = Parser::Source::Buffer.new('<code>', 1)
+      buffer.source = example.text
+      parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
+      parser.diagnostics.all_errors_are_fatal = true
+      parser.parse(buffer)
+    rescue Parser::SyntaxError => e
+      path = example.object.file
+      puts "#{path}: Syntax Error in an example. #{e}"
+      ok = false
     end
   end
   abort unless ok

--- a/test/assertion_helper.rb
+++ b/test/assertion_helper.rb
@@ -8,7 +8,7 @@ module AssertionHelper
   private
 
   def setup
-    cop_name = self.class.to_s.sub(/Test\z/, '')
+    cop_name = self.class.to_s.delete_suffix('Test')
 
     @cop = RuboCop::Cop::Minitest.const_get(cop_name).new
   end
@@ -88,6 +88,6 @@ module AssertionHelper
   end
 
   def ruby_version
-    2.4
+    2.5
   end
 end


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/9648.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
