### PR TITLE
[Fix #131] Fix an error for `Minitest/MultipleAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#131](https://github.com/rubocop/rubocop-minitest/issues/131): Fix an error for `Minitest/MultipleAssertions` and fixes a false positive for `test` block. ([@koic][])
+
 ## 0.12.0 (2021-04-23)
 
 ### New features

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -44,8 +44,7 @@ module RuboCop
       end
 
       def test_cases(class_node)
-        (class_def_nodes(class_node).select { |def_node| test_case_name?(def_node.method_name) }) +
-          test_method_calls(class_node)
+        class_def_nodes(class_node).select { |def_node| test_case_name?(def_node.method_name) }
       end
 
       def lifecycle_hooks(class_node)
@@ -62,12 +61,6 @@ module RuboCop
         else
           class_def.each_child_node(:def).to_a
         end
-      end
-
-      # support https://api.rubyonrails.org/classes/ActiveSupport/Testing/Declarative.html
-      def test_method_calls(class_node)
-        block_nodes = class_node.each_descendant(:block)
-        block_nodes.select { |block_node| block_node.method?(:test) }
       end
 
       def test_case_name?(name)

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -93,6 +93,17 @@ class MultipleAssertionsTest < Minitest::Test
     assert_equal({ 'Max' => 2 }, @cop.config_to_allow_offenses[:exclude_limit])
   end
 
+  def test_does_not_register_offense_when_multiple_expectations_in_the_test_block
+    assert_no_offenses(<<~RUBY)
+      class FooTest < ActiveSupport::TestCase
+        test 'something' do
+          assert_equal(foo, bar)
+          assert_empty(array)
+        end
+      end
+    RUBY
+  end
+
   private
 
   def configure_max_assertions(max)

--- a/test/rubocop/cop/minitest/no_assertions_test.rb
+++ b/test/rubocop/cop/minitest/no_assertions_test.rb
@@ -26,8 +26,8 @@ class NoAssertionsTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_no_assertions_in_block_form
-    assert_offense(<<~RUBY)
+  def test_does_not_register_offense_when_no_assertions_in_block_form
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         include Foo
 
@@ -39,7 +39,6 @@ class NoAssertionsTest < Minitest::Test
         end
 
         test "the truth" do
-        ^^^^^^^^^^^^^^^^^^^ Test case has no assertions.
         end
 
         test "another valid test" do


### PR DESCRIPTION
Fixes #131.

This PR fixes an error for `Minitest/MultipleAssertions` and fixes a false positive for `test` block.

Since RuboCop Minitest is a gem for Minitest, it should not support `ActiveSupport::TestCase` feature `test` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
