### PR TITLE
Include `Minitest::Spec` path by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#135](https://github.com/rubocop/rubocop-minitest/pull/135): Include `Minitest::Spec` path (`'**/test/**/*_spec.rb`) by defalt. ([@koic][])
+
 ## 0.12.1 (2021-04-25)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,6 +3,7 @@ Minitest:
   Include:
     - '**/test/**/*'
     - '**/*_test.rb'
+    - '**/test/**/*_spec.rb' # For Minitest::Spec
 
 Minitest/AssertEmpty:
   Description: 'This cop enforces the test to use `assert_empty` instead of using `assert(object.empty?)`.'


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop-minitest/issues/134.

This PR includes `'**/test/**/*_spec.rb'` compliant Minitest::Spec.
https://github.com/seattlerb/minitest/blob/v5.14.4/test/minitest/test_minitest_spec.rb

However, it doesn't include `'**/spec/**/*_spec.rb'` for the following reasons:

- Not officially present in Minitest
- Prevent false positives for RuboCop RSpec

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
