### PR TITLE
[Fix #143] Fix an error for `Minitest/LiteralAsActualArgumentTest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#143](https://github.com/rubocop/rubocop-minitest/issues/143): Fix an error for `Minitest/LiteralAsActualArgumentTest` when expected and actual arguments are literals. ([@koic][])
+
 ## 0.15.0 (2021-08-09)
 
 ### New features

--- a/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
+++ b/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
@@ -27,17 +27,16 @@ module RuboCop
         def on_send(node)
           return unless node.method?(:assert_equal)
 
-          actual = node.arguments[1]
+          expected, actual, message = *node.arguments
           return unless actual&.recursive_basic_literal?
+          return if expected.recursive_basic_literal?
 
           add_offense(all_arguments_range(node)) do |corrector|
-            autocorrect(corrector, node)
+            autocorrect(corrector, node, expected, actual, message)
           end
         end
 
-        def autocorrect(corrector, node)
-          expected, actual, message = *node.arguments
-
+        def autocorrect(corrector, node, expected, actual, message)
           new_actual_source = if actual.hash_type? && !actual.braces?
                                 "{#{actual.source}}"
                               else

--- a/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
+++ b/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
@@ -99,4 +99,14 @@ class LiteralAsActualArgumentTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_expected_and_actual_are_basic_literals
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal 0, 1, 'message'
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #143.

This PR fixes an error for `Minitest/LiteralAsActualArgumentTest` when expected and actual arguments are literals.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
