### PR TITLE
Mark `Minitest/AssertEmptyLiteral` as safe auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#144](https://github.com/rubocop/rubocop-minitest/pull/144): Mark `Minitest/AssertEmptyLiteral` as safe auto-correction. ([@koic][])
+
 ## 0.15.1 (2021-09-26)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,9 +11,8 @@ Minitest/AssertEmpty:
   VersionAdded: '0.2'
 
 Minitest/AssertEmptyLiteral:
-  Description: 'This cop enforces the test to use `assert_empty` instead of using `assert([], object)` or `assert({}, object)`.'
+  Description: 'This cop enforces the test to use `assert_empty` instead of using `assert_equal([], object)`.'
   Enabled: true
-  SafeAutoCorrect: false
   VersionAdded: '0.5'
   VersionChanged: '0.11'
 

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -39,13 +39,13 @@ assert_empty(object, 'message')
 
 | Enabled
 | Yes
-| Yes (Unsafe)
+| Yes
 | 0.5
 | 0.11
 |===
 
 This cop enforces the test to use `assert_empty`
-instead of using `assert_equal([], object)`.
+instead of using `assert_equal([], object)` or `assert_equal({}, object)`.
 
 === Examples
 

--- a/lib/rubocop/cop/minitest/assert_empty_literal.rb
+++ b/lib/rubocop/cop/minitest/assert_empty_literal.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `assert_empty`
-      # instead of using `assert_equal([], object)`.
+      # instead of using `assert_equal([], object)` or `assert_equal({}, object)`.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR marks `Minitest/AssertEmptyLiteral` as safe auto-correction.
Introduced as unsafe auto-correction in #85, but now safe auto-correction with changes in #118.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
