### PR TITLE
[Fix #147] Minitest/GlobalExpectations: add EnforcedStyle config value

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,8 @@
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.
 Metrics/MethodLength:
   Max: 14
+  Exclude:
+    - 'test/rubocop/cop/minitest/global_expectations_test.rb'
 
 # Offense count: 1
 Style/DocumentDynamicEvalDefinition:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#147](https://github.com/rubocop/rubocop-minitest/issues/147): Add `EnforcedStyle` config parameter for `Minitest/GlobalExpectations`. ([@gi][])
+
 ### Bug fixes
 
 * [#142](https://github.com/rubocop/rubocop-minitest/issues/142): Fix `Minitest/GlobalExpectations` autocorrect when receiver is lambda. ([@gi][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -103,7 +103,19 @@ Minitest/GlobalExpectations:
   Description: 'This cop checks for deprecated global expectations.'
   StyleGuide: 'https://minitest.rubystyle.guide#global-expectations'
   Enabled: true
+  EnforcedStyle: any
+  Include:
+    - '**/test/**/*'
+    - '**/*_test.rb'
+    - '**/spec/**/*'
+    - '**/*_spec.rb'
+  SupportedStyles:
+    - _
+    - any
+    - expect
+    - value
   VersionAdded: '0.7'
+  VersionChanged: '0.16'
 
 Minitest/LiteralAsActualArgument:
   Description: 'This cop enforces correct order of `expected` and `actual` arguments for `assert_equal`.'

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -519,13 +519,38 @@ end
 | Yes
 | Yes
 | 0.7
-| -
+| 0.16
 |===
 
 This cop checks for deprecated global expectations
 and autocorrects them to use expect format.
 
 === Examples
+
+==== EnforcedStyle: _
+
+[source,ruby]
+----
+# bad
+musts.must_equal expected_musts
+wonts.wont_match expected_wonts
+musts.must_raise TypeError
+
+expect(musts).must_equal expected_musts
+expect(wonts).wont_match expected_wonts
+expect { musts }.must_raise TypeError
+
+value(musts).must_equal expected_musts
+value(wonts).wont_match expected_wonts
+value { musts }.must_raise TypeError
+
+# good
+_(musts).must_equal expected_musts
+_(wonts).wont_match expected_wonts
+_ { musts }.must_raise TypeError
+----
+
+==== EnforcedStyle: any (default)
 
 [source,ruby]
 ----
@@ -538,7 +563,75 @@ musts.must_raise TypeError
 _(musts).must_equal expected_musts
 _(wonts).wont_match expected_wonts
 _ { musts }.must_raise TypeError
+
+expect(musts).must_equal expected_musts
+expect(wonts).wont_match expected_wonts
+expect { musts }.must_raise TypeError
+
+value(musts).must_equal expected_musts
+value(wonts).wont_match expected_wonts
+value { musts }.must_raise TypeError
 ----
+
+==== EnforcedStyle: expect
+
+[source,ruby]
+----
+# bad
+musts.must_equal expected_musts
+wonts.wont_match expected_wonts
+musts.must_raise TypeError
+
+_(musts).must_equal expected_musts
+_(wonts).wont_match expected_wonts
+_ { musts }.must_raise TypeError
+
+value(musts).must_equal expected_musts
+value(wonts).wont_match expected_wonts
+value { musts }.must_raise TypeError
+
+# good
+expect(musts).must_equal expected_musts
+expect(wonts).wont_match expected_wonts
+expect { musts }.must_raise TypeError
+----
+
+==== EnforcedStyle: value
+
+[source,ruby]
+----
+# bad
+musts.must_equal expected_musts
+wonts.wont_match expected_wonts
+musts.must_raise TypeError
+
+_(musts).must_equal expected_musts
+_(wonts).wont_match expected_wonts
+_ { musts }.must_raise TypeError
+
+expect(musts).must_equal expected_musts
+expect(wonts).wont_match expected_wonts
+expect { musts }.must_raise TypeError
+
+# good
+value(musts).must_equal expected_musts
+value(wonts).wont_match expected_wonts
+value { musts }.must_raise TypeError
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `any`
+| `_`, `any`, `expect`, `value`
+
+| Include
+| `+**/test/**/*+`, `+**/*_test.rb+`, `+**/spec/**/*+`, `+**/*_spec.rb+`
+| Array
+|===
 
 === References
 


### PR DESCRIPTION

Add a new configuration value for Minitest/GlobalExpectations: EnforcedStyle.
This value sets the allowed and preferred method(s) with which to detect and
correct errors.

Fixes #147

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
