### PR TITLE
[Fix #142] Minitest/GlobalExpectations: autocorrect when receiver is lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#142](https://github.com/rubocop/rubocop-minitest/issues/142): Fix `Minitest/GlobalExpectations` autocorrect when receiver is lambda. ([@gi][])
+
 ## 0.15.2 (2021-10-11)
 
 ### Bug fixes
@@ -246,3 +250,4 @@
 [@tsmmark]: https://github.com/tsmmark
 [@cstyles]: https://github.com/cstyles
 [@ghiculescu]: https://github.com/ghiculescu
+[@gi]: https://github.com/gi

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -67,25 +67,27 @@ module RuboCop
 
           message = format(MSG, preferred: preferred_receiver(node))
 
-          add_offense(node.receiver.source_range, message: message) do |corrector|
-            receiver = node.receiver.source_range
-
-            if BLOCK_MATCHERS.include?(node.method_name)
-              corrector.wrap(receiver, '_ { ', ' }')
-            else
-              corrector.wrap(receiver, '_(', ')')
-            end
+          add_offense(node.receiver, message: message) do |corrector|
+            receiver = node.receiver
+            replacement = preferred_receiver(node)
+            corrector.replace(receiver, replacement)
           end
         end
 
         private
 
+        def preferred_method
+          :_
+        end
+
         def preferred_receiver(node)
-          source = node.receiver.source
+          receiver = node.receiver
+
           if BLOCK_MATCHERS.include?(node.method_name)
-            "_ { #{source} }"
+            body = receiver.lambda? ? receiver.body : receiver
+            "#{preferred_method} { #{body.source} }"
           else
-            "_(#{source})"
+            "#{preferred_method}(#{receiver.source})"
           end
         end
       end

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -256,6 +256,21 @@ class GlobalExpectationsTest < Minitest::Test
       RUBY
     end
 
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_and_block") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          -> { n }.#{matcher} 42
+          ^^^^^^^^ Use `_ { n }` instead.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          _ { n }.#{matcher} 42
+        end
+      RUBY
+    end
+
     define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}") do
       assert_no_offenses(<<~RUBY)
         it 'does something' do


### PR DESCRIPTION
This fixes an issue when autocorrecting offenses where the receiver is
a lambda function: `-> { n }`.

The expected correct result is `_ { n }` instead of `_ { -> { n } }`.

Fixes #142 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
