### PR TITLE
[Fix #150] Fix a false positive for `Minitest/AssertEmpty` and `RefuteEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#142](https://github.com/rubocop/rubocop-minitest/issues/142): Fix `Minitest/GlobalExpectations` autocorrect when receiver is lambda. ([@gi][])
+* [#150](https://github.com/rubocop/rubocop-minitest/issues/150): Fix a false positive for `Minitest/AssertEmpty` and `RefuteEmpty` cops when using `empty` method with any arguments. ([@koic][])
 
 ## 0.15.2 (2021-10-11)
 

--- a/lib/rubocop/cop/minitest/assert_empty.rb
+++ b/lib/rubocop/cop/minitest/assert_empty.rb
@@ -19,6 +19,17 @@ module RuboCop
         extend MinitestCopRule
 
         define_rule :assert, target_method: :empty?
+
+        def on_send(node)
+          return unless node.method?(:assert)
+          return unless (arguments = peel_redundant_parentheses_from(node.arguments))
+          return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:empty?)
+          return unless arguments.first.arguments.empty?
+
+          add_offense(node, message: offense_message(arguments)) do |corrector|
+            autocorrect(corrector, node, arguments)
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_empty.rb
+++ b/lib/rubocop/cop/minitest/refute_empty.rb
@@ -19,6 +19,17 @@ module RuboCop
         extend MinitestCopRule
 
         define_rule :refute, target_method: :empty?
+
+        def on_send(node)
+          return unless node.method?(:refute)
+          return unless (arguments = peel_redundant_parentheses_from(node.arguments))
+          return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:empty?)
+          return unless arguments.first.arguments.empty?
+
+          add_offense(node, message: offense_message(arguments)) do |corrector|
+            autocorrect(corrector, node, arguments)
+          end
+        end
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -94,4 +94,14 @@ class AssertEmptyTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assert_empty_method_with_any_arguments
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(File.empty?(path))
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/refute_empty_test.rb
+++ b/test/rubocop/cop/minitest/refute_empty_test.rb
@@ -94,4 +94,14 @@ class RefuteEmptyTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_refute_empty_method_with_any_arguments
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(File.empty?(path))
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #150.

This PR fixes a false positive for `Minitest/AssertEmpty` and `RefuteEmpty` cops when using `empty` method with any arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
