### PR TITLE
[Fix #152] Add `AdditionalMethods` configuration to `Minitest/GlobalExpectations`

### DIFF
--- a/changelog/change_add_extension_matchers_to_global_expectations.md
+++ b/changelog/change_add_extension_matchers_to_global_expectations.md
@@ -1,0 +1,1 @@
+* [#152](https://github.com/rubocop/rubocop-minitest/issues/152): Add `ExtensionMatchers` configuration to `Minitest/GlobalExpectations`. ([@tejasbubane][])

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -619,6 +619,19 @@ value(wonts).wont_match expected_wonts
 value { musts }.must_raise TypeError
 ----
 
+==== ExtensionMatchers: ['must_match_array']
+
+[source,ruby]
+----
+# bad
+musts.must_match_array expected_musts
+
+# good
+_(musts).must_match_array expected_musts
+expect(musts).must_match_array expected_musts
+value(musts).must_match_array expected_musts
+----
+
 === Configurable attributes
 
 |===

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -11,7 +11,7 @@ class GlobalExpectationsTest < Minitest::Test
     :any
   end
 
-  RuboCop::Cop::Minitest::GlobalExpectations::VALUE_MATCHERS.each do |matcher|
+  (RuboCop::Cop::Minitest::GlobalExpectations::VALUE_MATCHERS + %w[must_match_array wont_match_array]).each do |matcher|
     define_method(:"test_registers_offense_when_using_global_#{matcher}") do
       assert_offense(<<~RUBY)
         it 'does something' do
@@ -505,6 +505,7 @@ class GlobalExpectationsTest < Minitest::Test
     all_config = RuboCop::Minitest::CONFIG
     cop_config = all_config['Minitest/GlobalExpectations']
     cop_config = cop_config.merge('EnforcedStyle' => style)
+    cop_config = cop_config.merge('ExtensionMatchers' => %w[must_match_array wont_match_array])
     all_config = all_config.merge('Minitest/GlobalExpectations' => cop_config)
     config = RuboCop::Config.new(all_config)
     @cop = RuboCop::Cop::Minitest::GlobalExpectations.new(config)


### PR DESCRIPTION
Closes #152

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/