### PR TITLE
Make `Minitest/UnreachableAssertion` aware of `assert` and `refute` prefix methods

### DIFF
--- a/changelog/change_minitest_unreachable_assertion_aware_of_assertion_prefix_method.md
+++ b/changelog/change_minitest_unreachable_assertion_aware_of_assertion_prefix_method.md
@@ -1,0 +1,1 @@
+* [#158](https://github.com/rubocop/rubocop-minitest/pull/158): Make `Minitest/UnreachableAssertion` aware of `assert` and `refute` prefix methods. ([@koic][])

--- a/lib/rubocop/cop/minitest/assertion_in_lifecycle_hook.rb
+++ b/lib/rubocop/cop/minitest/assertion_in_lifecycle_hook.rb
@@ -30,7 +30,7 @@ module RuboCop
 
           lifecycle_hooks(class_node).each do |hook_node|
             hook_node.each_descendant(:send) do |node|
-              if assertion?(node)
+              if assertion_method?(node)
                 message = format(MSG, assertion: node.method_name, hook: hook_node.method_name)
                 add_offense(node, message: message)
               end

--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -50,7 +50,7 @@ module RuboCop
         private
 
         def assertions_count(node)
-          base = assertion?(node) ? 1 : 0
+          base = assertion_method?(node) ? 1 : 0
           base + node.each_child_node.sum { |c| assertions_count(c) }
         end
 

--- a/lib/rubocop/cop/minitest/no_assertions.rb
+++ b/lib/rubocop/cop/minitest/no_assertions.rb
@@ -39,7 +39,7 @@ module RuboCop
         private
 
         def assertions_count(node)
-          base = assertion?(node) ? 1 : 0
+          base = assertion_method?(node) ? 1 : 0
           base + node.each_child_node.sum { |c| assertions_count(c) }
         end
       end

--- a/lib/rubocop/cop/minitest/unreachable_assertion.rb
+++ b/lib/rubocop/cop/minitest/unreachable_assertion.rb
@@ -30,11 +30,9 @@ module RuboCop
 
           last_node = body.begin_type? ? body.children.last : body
           return unless last_node.send_type?
+          return unless assertion_method?(last_node)
 
-          method_name = last_node.method_name
-          return unless assertion_method?(method_name)
-
-          add_offense(last_node, message: format(MSG, assertion_method: method_name))
+          add_offense(last_node, message: format(MSG, assertion_method: last_node.method_name))
         end
       end
     end


### PR DESCRIPTION
This PR makes `Minitest/UnreachableAssertion` aware of `assert` and `refute` prefix methods and removes `MinitestExplorationHelpers#assertion?` method. It makes the detection to assertion methods consistent.

NOTE: The `MinitestExplorationHelpers#assertion?` method is redundant with `MinitestExplorationHelpers#assertion_method?` OTOH, the implementation uses
`MinitestExplorationHelpers#assertion` instead of `MinitestExplorationHelpers#assertion_method?`. Maybe it's enough to verify that it starts with `assert` or `refute` instead of exact match of the known assertion method names.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
