### PR TITLE
[Fix #159] Fix a false positive for `Minitest/UnreachableAssertion`

### DIFF
--- a/changelog/fix_false_positive_for_minitest_unreachable_assertion.md
+++ b/changelog/fix_false_positive_for_minitest_unreachable_assertion.md
@@ -1,0 +1,1 @@
+* [#159](https://github.com/rubocop/rubocop-minitest/issues/159): Fix a false positive for `Minitest/UnreachableAssertion` when using only one assertion method in `assert_raises` block. ([@koic][])

--- a/lib/rubocop/cop/minitest/unreachable_assertion.rb
+++ b/lib/rubocop/cop/minitest/unreachable_assertion.rb
@@ -30,7 +30,7 @@ module RuboCop
 
           last_node = body.begin_type? ? body.children.last : body
           return unless last_node.send_type?
-          return unless assertion_method?(last_node)
+          return if !assertion_method?(last_node) || !body.begin_type?
 
           add_offense(last_node, message: format(MSG, assertion_method: last_node.method_name))
         end

--- a/test/rubocop/cop/minitest/unreachable_assertion_test.rb
+++ b/test/rubocop/cop/minitest/unreachable_assertion_test.rb
@@ -40,6 +40,14 @@ class UnreachableAssertionTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_when_using_only_one_assertion_method_in_assert_raises_block
+    assert_no_offenses(<<~RUBY)
+      assert_raises(Minitest::Assertion) do
+        assert_response 200
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_empty_block_for_assert_raises
     assert_no_offenses(<<~RUBY)
       assert_raises FooError do


### PR DESCRIPTION
This PR fixes a false positive for `Minitest/UnreachableAssertion` when using only one assertion method in `assert_raises` block.

If `assert_raises` has only one assertion method, accept it considering the possibility of testing that assertion method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
