### PR TITLE
Make `Minitest/AssertNil` aware of `assert_predicate`

### DIFF
--- a/changelog/change_make_assert_nil_aware_of_assert_predicate.md
+++ b/changelog/change_make_assert_nil_aware_of_assert_predicate.md
@@ -1,0 +1,1 @@
+* [#162](https://github.com/rubocop/rubocop-minitest/pull/162): Make `Minitest/AssertNil` (`Minitest/RefuteNil`) aware of `assert_predicate(obj, :nil?)` (`refute_predicate(obj, :nil?)`). ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_nil.rb
+++ b/lib/rubocop/cop/minitest/assert_nil.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `assert_nil` instead of using
-      # `assert_equal(nil, something)` or `assert(something.nil?)`.
+      # `assert_equal(nil, something)`, `assert(something.nil?)`, or `assert_predicate(something, :nil?)`.
       #
       # @example
       #   # bad
@@ -12,6 +12,8 @@ module RuboCop
       #   assert_equal(nil, actual, 'message')
       #   assert(object.nil?)
       #   assert(object.nil?, 'message')
+      #   assert_predicate(object, :nil?)
+      #   assert_predicate(object, :nil?, 'message')
       #
       #   # good
       #   assert_nil(actual)
@@ -23,12 +25,13 @@ module RuboCop
         extend AutoCorrector
 
         ASSERTION_TYPE = 'assert'
-        RESTRICT_ON_SEND = %i[assert_equal assert].freeze
+        RESTRICT_ON_SEND = %i[assert assert_equal assert_predicate].freeze
 
         def_node_matcher :nil_assertion, <<~PATTERN
           {
             (send nil? :assert_equal nil $_ $...)
             (send nil? :assert (send $_ :nil?) $...)
+            (send nil? :assert_predicate $_ (sym :nil?) $...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/minitest/refute_nil.rb
+++ b/lib/rubocop/cop/minitest/refute_nil.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `refute_nil` instead of using
-      # `refute_equal(nil, something)` or `refute(something.nil?)`.
+      # `refute_equal(nil, something)`, `refute(something.nil?)`, or `refute_predicate(something, :nil?)`.
       #
       # @example
       #   # bad
@@ -12,6 +12,8 @@ module RuboCop
       #   refute_equal(nil, actual, 'message')
       #   refute(actual.nil?)
       #   refute(actual.nil?, 'message')
+      #   refute_predicate(object, :nil?)
+      #   refute_predicate(object, :nil?, 'message')
       #
       #   # good
       #   refute_nil(actual)
@@ -23,12 +25,13 @@ module RuboCop
         extend AutoCorrector
 
         ASSERTION_TYPE = 'refute'
-        RESTRICT_ON_SEND = %i[refute_equal refute].freeze
+        RESTRICT_ON_SEND = %i[refute refute_equal refute_predicate].freeze
 
         def_node_matcher :nil_refutation, <<~PATTERN
           {
             (send nil? :refute_equal nil $_ $...)
             (send nil? :refute (send $_ :nil?) $...)
+            (send nil? :refute_predicate $_ (sym :nil?) $...)
           }
         PATTERN
 

--- a/test/rubocop/cop/minitest/assert_nil_test.rb
+++ b/test/rubocop/cop/minitest/assert_nil_test.rb
@@ -8,7 +8,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_equal(nil, somestuff)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff)` over `assert_equal(nil, somestuff)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff)`.
         end
       end
     RUBY
@@ -27,7 +27,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_equal(nil, somestuff, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, 'message')` over `assert_equal(nil, somestuff, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, 'message')`.
         end
       end
     RUBY
@@ -46,7 +46,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_equal(nil, obj.do_something, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(obj.do_something, 'message')` over `assert_equal(nil, obj.do_something, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(obj.do_something, 'message')`.
         end
       end
     RUBY
@@ -65,7 +65,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_equal(nil, obj.do_something, <<~MESSAGE
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(obj.do_something, <<~MESSAGE)` over `assert_equal(nil, obj.do_something, <<~MESSAGE)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(obj.do_something, <<~MESSAGE)`.
             message
           MESSAGE
           )
@@ -90,7 +90,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert(somestuff.nil?)
-          ^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff)` over `assert(somestuff.nil?)`.
+          ^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff)`.
         end
       end
     RUBY
@@ -109,7 +109,7 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert(somestuff.nil?, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, 'message')` over `assert(somestuff.nil?, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, 'message')`.
         end
       end
     RUBY
@@ -118,6 +118,44 @@ class AssertNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_nil(somestuff, 'message')
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_predicate
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_predicate(object, :nil?)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_nil(object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_predicate_with_message
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_predicate(object, :nil?, 'message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(object, 'message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_nil(object, 'message')
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_nil_test.rb
+++ b/test/rubocop/cop/minitest/refute_nil_test.rb
@@ -8,7 +8,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal(nil, somestuff)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff)` over `refute_equal(nil, somestuff)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff)`.
         end
       end
     RUBY
@@ -27,7 +27,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal(nil, somestuff, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, 'message')` over `refute_equal(nil, somestuff, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, 'message')`.
         end
       end
     RUBY
@@ -46,7 +46,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal(nil, obj.do_something, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(obj.do_something, 'message')` over `refute_equal(nil, obj.do_something, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(obj.do_something, 'message')`.
         end
       end
     RUBY
@@ -65,7 +65,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal(nil, obj.do_something, <<~MESSAGE
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(obj.do_something, <<~MESSAGE)` over `refute_equal(nil, obj.do_something, <<~MESSAGE)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(obj.do_something, <<~MESSAGE)`.
             message
           MESSAGE
           )
@@ -90,7 +90,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute(somestuff.nil?)
-          ^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff)` over `refute(somestuff.nil?)`.
+          ^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff)`.
         end
       end
     RUBY
@@ -109,7 +109,7 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute(somestuff.nil?, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, 'message')` over `refute(somestuff.nil?, 'message')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, 'message')`.
         end
       end
     RUBY
@@ -118,6 +118,44 @@ class RefuteNilTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_nil(somestuff, 'message')
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_predicate
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_predicate(object, :nil?)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_nil(object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_predicate_with_message
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_predicate(object, :nil?, 'message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(object, 'message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_nil(object, 'message')
         end
       end
     RUBY


### PR DESCRIPTION
This PR makes `Minitest/AssertNil` (`Minitest/RefuteNil`) aware of `assert_predicate(obj, :nil?)` (`refute_predicate(obj, :nil?)`).

Also tweak the redundant offense messages to simplify the implementation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
