### PR TITLE
Protect against missing parents

### DIFF
--- a/changelog/fix_missing_parents_in_duplicated_test_run_cop.md
+++ b/changelog/fix_missing_parents_in_duplicated_test_run_cop.md
@@ -1,0 +1,1 @@
+* [#167](https://github.com/rubocop/rubocop-minitest/pull/167): Fix potential for valid Ruby code to be unparsable in `Minitest/DuplicateTestRun` cop. ([@gjtorikian][])

--- a/lib/rubocop/cop/minitest/duplicate_test_run.rb
+++ b/lib/rubocop/cop/minitest/duplicate_test_run.rb
@@ -63,7 +63,10 @@ module RuboCop
 
         def parent_class_has_test_methods?(class_node)
           parent_class = class_node.parent_class
-          parent_class_node = class_node.parent.each_child_node(:class).detect do |klass|
+
+          return false unless (class_node_parent = class_node.parent)
+
+          parent_class_node = class_node_parent.each_child_node(:class).detect do |klass|
             klass.identifier == parent_class
           end
 

--- a/test/rubocop/cop/minitest/duplicate_test_run_test.rb
+++ b/test/rubocop/cop/minitest/duplicate_test_run_test.rb
@@ -103,4 +103,17 @@ class DuplicateTestRunTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_throw_error_if_missing_parent_test_class
+    assert_no_offenses(<<~RUBY)
+      class PostmarkAccountServiceTest < ActionDispatch::IntegrationTest
+        test "it handles missing payloads from Postmark Account API errors" do
+          Postmark::AccountApiClient.any_instance.stubs(:create_server).raises(StandardError)
+
+          Rails.logger.expects(:error)
+          PostmarkAccountService.create_server({})
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
There's a slight logical error in the recent `DuplicateTestRun` addition.

Totally legit Ruby code can be marked as unparseable by this test:

```
         parent_class_node = class_node_parent.each_child_node(:class).detect do |klass|
                              ^^^^^^^^^^^^^^^^^
Did you mean?  class_node
    /Users/gjtorikian/Development/rubocop-minitest/lib/rubocop/cop/minitest/duplicate_test_run.rb:69:in `parent_class_has_test_methods?'
    /Users/gjtorikian/Development/rubocop-minitest/lib/rubocop/cop/minitest/duplicate_test_run.rb:56:in `on_class'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:100:in `public_send'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:100:in `block (2 levels) in trigger_responding_cops'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:99:in `block in trigger_responding_cops'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:98:in `each'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:98:in `trigger_responding_cops'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:69:in `on_class'
    /Users/gjtorikian/.gem/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:136:in `block in on_dstr'
    /Users/gjtorikian/.gem/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:136:in `each'
    /Users/gjtorikian/.gem/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:136:in `on_dstr'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:71:in `on_begin'
    /Users/gjtorikian/.gem/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:20:in `walk'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/commissioner.rb:86:in `investigate'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/team.rb:155:in `investigate_partial'
    /Users/gjtorikian/.gem/bundler/gems/rubocop-2d3a972cb12b/lib/rubocop/cop/team.rb:83:in `investigate'
    /Users/gjtorikian/Development/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:114:in `_investigate'
    /Users/gjtorikian/Development/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:105:in `assert_offense'
    /Users/gjtorikian/Development/rubocop-minitest/test/rubocop/cop/minitest/duplicate_test_run_test.rb:23:in `test_registers_offense_when_parent_and_children_have_tests_methods'
```

The solution to this is to not assume that every test file has a parent class. I added a failing test case to demonstrate this bug, and then the second commit is the change to fix it. 