### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.5
-          image: cimg/ruby:2.5
-      - rake_default:
           name: Ruby 2.6
           image: cimg/ruby:2.6
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/changelog/change_drop_ruby_2_5_support.md
+++ b/changelog/change_drop_ruby_2_5_support.md
@@ -1,0 +1,1 @@
+* [#168](https://github.com/rubocop/rubocop-minitest/pull/168): **(Breaking)** Drop Ruby 2.5 support. ([@koic][])

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.license = 'MIT'
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
   spec.metadata = {
     'homepage_uri' => 'https://docs.rubocop.org/rubocop-minitest/',
     'changelog_uri' => 'https://github.com/rubocop/rubocop-minitest/blob/master/CHANGELOG.md',


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10577.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
