### PR TITLE
[Fix #172] Fix a false positive for `Minitest/AssertPredicate`

### DIFF
--- a/changelog/fix_a_false_positive_for_minitest_assert_predicate.md
+++ b/changelog/fix_a_false_positive_for_minitest_assert_predicate.md
@@ -1,0 +1,1 @@
+* [#172](https://github.com/rubocop/rubocop-minitest/issues/172): Fix a false positive for `Minitest/AssertPredicate` and `Minitest/RefutePredicate` when using numbered parameters. ([@koic][])

--- a/lib/rubocop/cop/mixin/predicate_assertion_handleable.rb
+++ b/lib/rubocop/cop/mixin/predicate_assertion_handleable.rb
@@ -10,8 +10,12 @@ module RuboCop
 
         def on_send(node)
           return unless (arguments = peel_redundant_parentheses_from(node.arguments))
-          return unless arguments.first.respond_to?(:predicate_method?) && arguments.first.predicate_method?
-          return unless arguments.first.arguments.count.zero?
+
+          first_argument = arguments.first
+
+          return if first_argument.block_type? || first_argument.numblock_type?
+          return unless first_argument.respond_to?(:predicate_method?) && first_argument.predicate_method?
+          return unless first_argument.arguments.count.zero?
 
           add_offense(node, message: offense_message(arguments)) do |corrector|
             autocorrect(corrector, node, arguments)

--- a/test/rubocop/cop/minitest/assert_predicate_test.rb
+++ b/test/rubocop/cop/minitest/assert_predicate_test.rb
@@ -142,4 +142,14 @@ class AssertPredicateTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assert_with_predicate_method_and_numbered_parameters
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert([1, 2, 3].any? { some_filter_function _1 })
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/refute_predicate_test.rb
+++ b/test/rubocop/cop/minitest/refute_predicate_test.rb
@@ -142,4 +142,14 @@ class RefutePredicateTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_refute_with_predicate_method_and_numbered_parameters
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute([1, 2, 3].any? { some_filter_function _1 })
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #172.

This PR fixes a false positive for `Minitest/AssertPredicate` and `Minitest/RefutePredicate` when using numbered parameters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
