### PR TITLE
Fix raise error when usgin assert with block

### DIFF
--- a/changelog/fix_raise_error_using_assert_with_block.md
+++ b/changelog/fix_raise_error_using_assert_with_block.md
@@ -1,0 +1,1 @@
+* [#175](https://github.com/rubocop/rubocop-minitest/pull/175): Fix raise error when using assert with block. ([@ippachi][])

--- a/lib/rubocop/cop/mixin/predicate_assertion_handleable.rb
+++ b/lib/rubocop/cop/mixin/predicate_assertion_handleable.rb
@@ -13,8 +13,9 @@ module RuboCop
 
           first_argument = arguments.first
 
+          return unless first_argument
           return if first_argument.block_type? || first_argument.numblock_type?
-          return unless first_argument.respond_to?(:predicate_method?) && first_argument.predicate_method?
+          return unless predicate_method?(first_argument)
           return unless first_argument.arguments.count.zero?
 
           add_offense(node, message: offense_message(arguments)) do |corrector|
@@ -36,6 +37,10 @@ module RuboCop
           return arguments unless arguments.first&.begin_type?
 
           peel_redundant_parentheses_from(arguments.first.children)
+        end
+
+        def predicate_method?(first_argument)
+          first_argument.respond_to?(:predicate_method?) && first_argument.predicate_method?
         end
 
         def offense_message(arguments)

--- a/test/rubocop/cop/minitest/assert_predicate_test.rb
+++ b/test/rubocop/cop/minitest/assert_predicate_test.rb
@@ -152,4 +152,14 @@ class AssertPredicateTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_raise_error_using_assert_with_block
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert { true }
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
rubocop-minitest was raising error if the style was to pass a block to an assert, such as power-assert.
So, I made it so that such cases are ignored.

This is stacktrace.
```
  1) Error:
AssertPredicateTest#test_does_not_raise_error_using_assert_with_block:
NoMethodError: undefined method `block_type?' for nil:NilClass

          return if first_argument.block_type? || first_argument.numblock_type?
                                  ^^^^^^^^^^^^
    /Users/ippachi/ghq/github.com/ippachi/rubocop-minitest/lib/rubocop/cop/mixin/predicate_assertion_handleable.rb:16:in `on_send'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:136:in `public_send'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:136:in `block (2 levels) in trigger_restricted_cops'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:135:in `block in trigger_restricted_cops'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:134:in `each'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:134:in `trigger_restricted_cops'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:70:in `on_send'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.18.0/lib/rubocop/ast/traversal.rb:153:in `on_block'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:71:in `on_block'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.18.0/lib/rubocop/ast/traversal.rb:153:in `on_def'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:71:in `on_def'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.18.0/lib/rubocop/ast/traversal.rb:153:in `on_class'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:71:in `on_class'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.18.0/lib/rubocop/ast/traversal.rb:20:in `walk'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/commissioner.rb:86:in `investigate'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/team.rb:155:in `investigate_partial'
    /Users/ippachi/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-f133b38b5893/lib/rubocop/cop/team.rb:83:in `investigate'
    /Users/ippachi/ghq/github.com/ippachi/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:114:in `_investigate'
    /Users/ippachi/ghq/github.com/ippachi/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:153:in `inspect_source'
    /Users/ippachi/ghq/github.com/ippachi/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:85:in `assert_no_offenses'
    /Users/ippachi/ghq/github.com/ippachi/rubocop-minitest/test/rubocop/cop/minitest/assert_predicate_test.rb:157:in `test_does_not_raise_error_using_assert_with_block'
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
