### PR TITLE
Fix incorrect documentation URLs when using `rubocop --show-docs-url`

### DIFF
--- a/changelog/fix_incorrect_documentation_urls.md
+++ b/changelog/fix_incorrect_documentation_urls.md
@@ -1,0 +1,1 @@
+* [#178](https://github.com/rubocop/rubocop-minitest/pull/178): Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,6 @@
 Minitest:
   Enabled: true
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-minitest
   Include:
     - '**/test/**/*'
     - '**/*_test.rb'


### PR DESCRIPTION
Added `DocumentationBaseURL` for `rubocop --show-docs-url [COP1,COP2,...]` command to work correctly for rubocop-minitest cops.

### Before

```console
$ bundle exec rubocop --show-docs-url Minitest/AssertEmpty
https://docs.rubocop.org/rubocop/cops_minitest.html#minitestassertempty
```

### After

```console
$ bundle exec rubocop --show-docs-url Minitest/AssertEmpty
https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestassertempty
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
