### PR TITLE
Fix an incorrect autocorrect for `Minitest/AssertMatch`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_minitest_assert_match.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_minitest_assert_match.md
@@ -1,0 +1,1 @@
+* [#181](https://github.com/rubocop/rubocop-minitest/pull/181): Fix an incorrect autocorrect for `Minitest/AssertMatch` when `assert` with `match` and RHS is a regexp literal. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_match.rb
+++ b/lib/rubocop/cop/minitest/assert_match.rb
@@ -18,7 +18,7 @@ module RuboCop
       class AssertMatch < Base
         extend MinitestCopRule
 
-        define_rule :assert, target_method: :match
+        define_rule :assert, target_method: :match, inverse: 'regexp_type?'
       end
     end
   end

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -19,7 +19,8 @@ module RuboCop
       #                                  autocorrection. The preferred method name that connects
       #                                  `assertion_method` and `target_method` with `_` is
       #                                  the default name.
-      # @param inverse [Boolean] An optional param. Order of arguments replaced by autocorrection.
+      # @param inverse [Boolean, String] An optional param. Order of arguments replaced by autocorrection.
+      #                                  If string is passed, it becomes a predicate method for the first argument node.
       # @api private
       #
       def define_rule(assertion_method, target_method:, preferred_method: nil, inverse: false)
@@ -78,10 +79,15 @@ module RuboCop
 
           def new_arguments(arguments)
             receiver = correct_receiver(arguments.first.receiver)
-            method_argument = arguments.first.arguments.first&.source
+            method_argument = arguments.first.arguments.first
 
-            new_arguments = [receiver, method_argument].compact
-            new_arguments.reverse! if #{inverse}
+            new_arguments = [receiver, method_argument&.source].compact
+            inverse_condition = if %w[true false].include?('#{inverse}')
+              #{inverse}
+            else
+              method_argument.#{inverse}
+            end
+            new_arguments.reverse! if inverse_condition
             new_arguments
           end
 

--- a/test/rubocop/cop/minitest/assert_match_test.rb
+++ b/test/rubocop/cop/minitest/assert_match_test.rb
@@ -22,6 +22,44 @@ class AssertMatchTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_match_and_lhs_is_regexp_literal
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(/regexp/.match(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(/regexp/, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match(/regexp/, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_match_and_rhs_is_regexp_literal
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(object.match(/regexp/))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(/regexp/, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match(/regexp/, object)
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_assert_with_match_and_message
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Minitest/AssertMatch` when `assert` with `match` and RHS is a regexp literal.

A regular expression literal must be the first argument to `assert_match`. `TypeError: no implicit conversion of Regexp into String` will occur if it is passed as the second argument.

```ruby
assert_match(object, /regexp/) #=> TypeError: no implicit conversion of Regexp into String
```

This issue was found on https://github.com/faker-ruby/faker/pull/2556.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
