### PR TITLE
Fix an incorrect autocorrect for `Minitest/RefuteMatch`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_minitest_refute_match.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_minitest_refute_match.md
@@ -1,0 +1,1 @@
+* [#185](https://github.com/rubocop/rubocop-minitest/pull/185): Fix an incorrect autocorrect for `Minitest/RefuteMatch` when `refute` with `match` and RHS is a regexp literal. ([@koic][])

--- a/lib/rubocop/cop/minitest/refute_match.rb
+++ b/lib/rubocop/cop/minitest/refute_match.rb
@@ -18,7 +18,7 @@ module RuboCop
       class RefuteMatch < Base
         extend MinitestCopRule
 
-        define_rule :refute, target_method: :match
+        define_rule :refute, target_method: :match, inverse: 'regexp_type?'
       end
     end
   end

--- a/test/rubocop/cop/minitest/refute_match_test.rb
+++ b/test/rubocop/cop/minitest/refute_match_test.rb
@@ -22,6 +22,44 @@ class RefuteMatchTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_match_and_lhs_is_regexp_literal
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(/regexp/.match(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_match(/regexp/, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_match(/regexp/, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_match_and_rhs_is_regexp_literal
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(object.match(/regexp/))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_match(/regexp/, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_match(/regexp/, object)
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_refute_with_match_and_message
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
@@ -90,6 +128,26 @@ class RefuteMatchTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_match(matcher, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_refute_with_no_arguments_match_call
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(matcher.match)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_refute_with_no_arguments_match_safe_navigation_call
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(matcher&.match)
         end
       end
     RUBY


### PR DESCRIPTION
Follow up #181 and #184.

This PR fixes an incorrect autocorrect for `Minitest/AssertMatch` when `refute` with `match` and RHS is a regexp literal.

A regular expression literal must be the first argument to `refute_match`. `TypeError: no implicit conversion of Regexp into String` will occur if it is passed as the second argument.

```ruby
refute_match(object, /regexp/) #=> TypeError: no implicit conversion of Regexp into String
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
