### PR TITLE
Fix a false negative for `Minitest/EmptyLineBeforeAssertionMethods`

### DIFF
--- a/changelog/fix_false_negative_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_false_negative_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#189](https://github.com/rubocop/rubocop-minitest/issues/189): Fix a false negative for `Minitest/EmptyLineBeforeAssertionMethods` when using non assertion method statement before assertion method used in a block. ([@koic][])

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -22,6 +22,7 @@ class ProjectTest < Minitest::Test
 
   def test_changelog_has_link_definitions_for_all_implicit_links
     implicit_link_names = @changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
+
     implicit_link_names.each do |name|
       assert_includes(
         @changelog, "[#{name}]: http",

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -109,6 +109,46 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_statement_before_assertion_method_used_in_block
+    assert_offense(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+        set.each do |thing|
+        ^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+          refute_nil(thing)
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+
+        set.each do |thing|
+          refute_nil(thing)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_statement_before_single_line_assertion_method_used_in_block
+    assert_offense(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+        set.each { |thing| refute_nil(thing) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+
+        set.each { |thing| refute_nil(thing) }
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_empty_line_before_assertion_methods
     assert_no_offenses(<<~RUBY)
       def test_do_something
@@ -171,6 +211,36 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
         assert_not foo
         assert bar
       end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assertion_method_before_assertion_method_used_in_block
+    assert_no_offenses(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+
+        refute_nil(set)
+        set.each do |thing|
+          refute_nil(thing)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_statement_before_non_assertion_method_used_in_block
+    assert_no_offenses(<<~RUBY)
+      def test_do_something
+        set = Set.new([1,2,3])
+        set.each do |thing|
+          do_something(thing)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_only_non_assertion_method
+    assert_no_offenses(<<~RUBY)
+      do_something(thing)
     RUBY
   end
 end


### PR DESCRIPTION
Fixes part of #189.

This PR fixes a false negative for `Minitest/EmptyLineBeforeAssertionMethods` when using non assertion method statement before assertion method used in a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
