### PR TITLE
[Fix #190] Fix an incorrect autocorrect for `Minitest/EmptyLineBeforeAssertionMethods`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#190](https://github.com/rubocop/rubocop-minitest/issues/190): Fix an incorrect autocorrect for `Minitest/EmptyLineBeforeAssertionMethods` when using method call with source code comment before assertion method. ([@koic][])

--- a/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
+++ b/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
@@ -18,6 +18,7 @@ module RuboCop
       #
       class EmptyLineBeforeAssertionMethods < Base
         include MinitestExplorationHelpers
+        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Add empty line before assertion.'
@@ -65,7 +66,7 @@ module RuboCop
             range = if heredoc?(previous_line_node)
                       previous_line_node.loc.heredoc_end
                     else
-                      previous_line_node
+                      range_by_whole_lines(previous_line_node.source_range, include_final_newline: true)
                     end
 
             corrector.insert_after(range, "\n")

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -21,6 +21,24 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_method_call_with_comment_before_assertion_method
+    assert_offense(<<~RUBY)
+      def test_do_something
+        do_something # comment
+        assert_equal(expected, actual)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        do_something # comment
+
+        assert_equal(expected, actual)
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_method_call_with_line_breaked_args_before_assertion_method
     assert_offense(<<~RUBY)
       def test_do_something


### PR DESCRIPTION
Fixes #190.

This PR fixes an incorrect autocorrect for `Minitest/EmptyLineBeforeAssertionMethods` when using method call with source code comment before assertion method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
