### PR TITLE
Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethods`

### DIFF
--- a/changelog/fix_a_false_positive_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_a_false_positive_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#189](https://github.com/rubocop/rubocop-minitest/issues/189): Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethods` when using `rescue` before assertion method. ([@koic][])

--- a/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
+++ b/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
@@ -25,7 +25,7 @@ module RuboCop
         def on_send(node)
           return unless (assertion_method = assertion_method(node))
           return unless (previous_line_node = assertion_method.left_sibling)
-          return unless previous_line_node.is_a?(RuboCop::AST::Node)
+          return if node.parent.resbody_type?
           return if accept_previous_line?(previous_line_node, assertion_method)
 
           previous_line_node = previous_line_node.arguments.last if use_heredoc_argument?(previous_line_node)
@@ -45,7 +45,8 @@ module RuboCop
         end
 
         def accept_previous_line?(previous_line_node, node)
-          return true if previous_line_node.args_type? || node.parent.basic_conditional?
+          return true if !previous_line_node.is_a?(RuboCop::AST::Node) ||
+                         previous_line_node.args_type? || node.parent.basic_conditional?
 
           previous_line_node.send_type? && assertion_method?(previous_line_node)
         end

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -149,6 +149,32 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_statement_before_assertion_method_used_in_rescue
+    assert_offense(<<~'RUBY')
+      def test_do_something
+        yaml_load_paths.each do |path|
+          YAML.load_file(path)
+        rescue Psych::Exception => e
+          do_something
+          flunk("Error loading #{path}: #{e.inspect}")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~'RUBY')
+      def test_do_something
+        yaml_load_paths.each do |path|
+          YAML.load_file(path)
+        rescue Psych::Exception => e
+          do_something
+
+          flunk("Error loading #{path}: #{e.inspect}")
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_empty_line_before_assertion_methods
     assert_no_offenses(<<~RUBY)
       def test_do_something
@@ -233,6 +259,18 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
         set = Set.new([1,2,3])
         set.each do |thing|
           do_something(thing)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_rescue_before_assertion_method
+    assert_no_offenses(<<~'RUBY')
+      def test_do_something
+        yaml_load_paths.each do |path|
+          YAML.load_file(path)
+        rescue Psych::Exception => e
+          flunk("Error loading #{path}: #{e.inspect}")
         end
       end
     RUBY


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-minitest/issues/189#issuecomment-1298473301.

This PR fixes a false positive for `Minitest/EmptyLineBeforeAssertionMethods` when using `rescue` before assertion method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
