### PR TITLE
[Fix #189] Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethods`

### DIFF
--- a/changelog/fix_false_positive_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_false_positive_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#189](https://github.com/rubocop/rubocop-minitest/issues/189): Fix a false negative for `Minitest/EmptyLineBeforeAssertionMethods` when using assertion method used in block before assertion method. ([@koic][])

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -167,6 +167,70 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_non_assertion_method_used_in_single_line_block_before_assertion_method
+    assert_offense(<<~RUBY)
+      def test_do_something
+        set.each { |thing| do_something(thing) }
+        assert_equal 'This is really bad', error.message
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        set.each { |thing| do_something(thing) }
+
+        assert_equal 'This is really bad', error.message
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_non_assertion_method_used_in_multi_line_block_before_assertion_method
+    assert_offense(<<~RUBY)
+      def test_do_something
+        set.each do |thing|
+          refute_nil(thing)
+
+          do_something(thing)
+        end
+        assert_equal 'This is really bad', error.message
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        set.each do |thing|
+          refute_nil(thing)
+
+          do_something(thing)
+        end
+
+        assert_equal 'This is really bad', error.message
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_empty_block_before_assertion_method
+    assert_offense(<<~RUBY)
+      def test_do_something
+        set.each do |thing|
+        end
+        assert_equal 'This is really bad', error.message
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line before assertion.
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      def test_do_something
+        set.each do |thing|
+        end
+
+        assert_equal 'This is really bad', error.message
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_statement_before_assertion_method_used_in_rescue
     assert_offense(<<~'RUBY')
       def test_do_something
@@ -258,7 +322,7 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assertion_method_before_assertion_method_used_in_block
+  def test_does_not_register_offense_when_using_assertion_method_before_assertion_method_used_in_block
     assert_no_offenses(<<~RUBY)
       def test_do_something
         set = Set.new([1,2,3])
@@ -278,6 +342,28 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
         set.each do |thing|
           do_something(thing)
         end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assertion_method_used_in_single_line_block_before_assertion_method
+    assert_no_offenses(<<~RUBY)
+      def test_do_something
+        set.each { |thing| refute_nil(thing) }
+        assert_equal 'This is really bad', error.message
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assertion_method_used_in_multi_line_block_before_assertion_method
+    assert_no_offenses(<<~RUBY)
+      def test_do_something
+        set.each do |thing|
+          do_something
+
+          refute_nil(thing)
+        end
+        assert_equal 'This is really bad', error.message
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #189 and #194.

This PR fixes a false negative for `Minitest/EmptyLineBeforeAssertionMethods` when using assertion method used in block before assertion method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
