### PR TITLE
Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethods`

### DIFF
--- a/changelog/fix_false_positive_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_false_positive_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#189](https://github.com/rubocop/rubocop-minitest/issues/189): Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethods` when using an assertion method as the first line within a test block([@ryanquanz][])

--- a/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
+++ b/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
@@ -43,8 +43,10 @@ module RuboCop
         def assertion_method(node)
           return node if assertion_method?(node)
           return unless (parent = node.parent)
+          return unless parent.block_type?
+          return if parent.method?(:test)
 
-          node.parent if parent.block_type? && parent.body && assertion_method?(parent.body)
+          node.parent if parent.body && assertion_method?(parent.body)
         end
 
         def accept_previous_line?(previous_line_node, node)

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -385,4 +385,14 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
       do_something(thing)
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assertion_method_as_first_line_in_test_block_at_top_of_class
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        test "do something" do
+          assert_equal(expected, actual)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Co-authored-by: Ryan Quanz <ryan.quanz@shopify.com>

Fixes https://github.com/rubocop/rubocop-minitest/issues/196

`Minitest/EmptyLineBeforeAssertionMethods` expected `test` blocks where the first line contained an assertion to have a newline above them. This isn't desired when, for example, the test is at the top of a class. 

This PR fixes a false positive for `Minitest/EmptyLineBeforeAssertionMethods` when using an assertion method as the first line within a test block.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
