### PR TITLE
[Fix #200] Support `it` testing block for minitest/spec

### DIFF
--- a/changelog/new_support_it_block.md
+++ b/changelog/new_support_it_block.md
@@ -1,0 +1,1 @@
+* [#200](https://github.com/rubocop/rubocop-minitest/issues/200): Support `it` testing block for minitest/spec. ([@koic][])

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         # Support Active Support's `test 'example' { ... }` method.
         # https://api.rubyonrails.org/classes/ActiveSupport/Testing/Declarative.html
-        test_blocks = class_node.each_descendant(:block).select { |block_node| block_node.method?(:test) }
+        test_blocks = class_node.each_descendant(:block).select { |block| block.method?(:test) || block.method?(:it) }
 
         test_cases + test_blocks
       end

--- a/test/rubocop/cop/minitest/no_assertions_test.rb
+++ b/test/rubocop/cop/minitest/no_assertions_test.rb
@@ -26,7 +26,7 @@ class NoAssertionsTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_no_assertions_in_block_form
+  def test_registers_offense_when_no_assertions_in_test_block_form
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         include Foo
@@ -44,6 +44,25 @@ class NoAssertionsTest < Minitest::Test
 
         test "another valid test" do
           assert true
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_no_assertions_in_it_block_form
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        describe Foo do
+          setup { }
+          teardown { }
+
+          it "asserts the truth" do
+            assert true
+          end
+
+          it "does nothing" do
+          ^^^^^^^^^^^^^^^^^^^^ Test case has no assertions.
+          end
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #200.

This PR supports `it` testing block for minitest/spec.

`Minitest/GlobalExpectations` is already supported, so `it` testing block can also be supported by RuboCop Minitest.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
