### PR TITLE
Raise severity of some cops to warning

### DIFF
--- a/changelog/change_raise_severity_of_some_cops_to_warning.md
+++ b/changelog/change_raise_severity_of_some_cops_to_warning.md
@@ -1,0 +1,1 @@
+* [#204](https://github.com/rubocop/rubocop-minitest/pull/204): Raise severity of `Minitest/AssertRaisesWithRegexpArgument`, `Minitest/AssertWithExpectedArgument`, `Minitest/GlobalExpectations`, `Minitest/SkipEnsure`, and `Minitest/UnreachableAssertion` cops to warning. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -85,7 +85,9 @@ Minitest/AssertRaisesCompoundBody:
 Minitest/AssertRaisesWithRegexpArgument:
   Description: 'This cop enforces checks for regular expression literals passed to `assert_raises`.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '0.22'
+  VersionChanged: '<<next>>'
 
 Minitest/AssertRespondTo:
   Description: 'This cop enforces the test to use `assert_respond_to(object, :do_something)` over `assert(object.respond_to?(:do_something))`.'
@@ -108,8 +110,10 @@ Minitest/AssertTruthy:
 Minitest/AssertWithExpectedArgument:
   Description: 'This cop tries to detect when a user accidentally used `assert` when they meant to use `assert_equal`.'
   Enabled: pending
+  Severity: warning
   Safe: false
   VersionAdded: '0.11'
+  VersionChanged: '<<next>>'
 
 Minitest/AssertionInLifecycleHook:
   Description: 'This cop checks for usage of assertions in lifecycle hooks.'
@@ -131,6 +135,7 @@ Minitest/GlobalExpectations:
   Description: 'This cop checks for deprecated global expectations.'
   StyleGuide: 'https://minitest.rubystyle.guide#global-expectations'
   Enabled: true
+  Severity: warning
   EnforcedStyle: any
   Include:
     - '**/test/**/*'
@@ -143,7 +148,7 @@ Minitest/GlobalExpectations:
     - expect
     - value
   VersionAdded: '0.7'
-  VersionChanged: '0.16'
+  VersionChanged: '<<next>>'
 
 Minitest/LiteralAsActualArgument:
   Description: 'This cop enforces correct order of `expected` and `actual` arguments for `assert_equal`.'
@@ -237,7 +242,9 @@ Minitest/RefuteRespondTo:
 Minitest/SkipEnsure:
   Description: 'Checks that `ensure` call even if `skip`.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '0.20'
+  VersionChanged: '<<next>>'
 
 Minitest/TestMethodName:
   Description: 'This cop enforces that test method names start with `test_` prefix.'
@@ -247,7 +254,9 @@ Minitest/TestMethodName:
 Minitest/UnreachableAssertion:
   Description: 'This cop checks for an `assert_raises` block containing any unreachable assertions.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '0.14'
+  VersionChanged: '<<next>>'
 
 Minitest/UnspecifiedException:
   Description: 'This cop checks for a specified error in `assert_raises`.'


### PR DESCRIPTION
The cops below belong to linting, not style preference, so make set the severity to warning.

The following emulates warnings for deprecated APIs:

- Minitest/GlobalExpectations (https://github.com/rubocop/rubocop-minitest/issues/60)

The following suggests incorrect usage of APIs:

- Minitest/AssertRaisesWithRegexpArgument:
- Minitest/AssertWithExpectedArgument:
- Minitest/SkipEnsure:
- Minitest/UnreachableAssertion:

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
