### PR TITLE
[Fix #206] Make `Minitest/AssertWithExpectedArgument` aware of message variable

### DIFF
--- a/change_make_minitest_assert_with_expected_argument_aware_of_message_variable.md
+++ b/change_make_minitest_assert_with_expected_argument_aware_of_message_variable.md
@@ -1,0 +1,1 @@
+* [#206](https://github.com/rubocop/rubocop/issues/206): Make `Minitest/AssertWithExpectedArgument` aware of message variable. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_with_expected_argument.rb
+++ b/lib/rubocop/cop/minitest/assert_with_expected_argument.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Tries to detect when a user accidentally used
       # `assert` when they meant to use `assert_equal`.
       #
+      # NOTE: The second argument to the `assert` method named `message` and `msg` is allowed.
+      #       Because their names are inferred as message arguments.
+      #
       # @safety
       #   This cop is unsafe because it is not possible to determine
       #   whether the second argument of `assert` is a message or not.
@@ -19,10 +22,13 @@ module RuboCop
       #   assert_equal(3, my_list.length)
       #   assert_equal(expected, actual)
       #   assert(foo, 'message')
+      #   assert(foo, message)
+      #   assert(foo, msg)
       #
       class AssertWithExpectedArgument < Base
         MSG = 'Did you mean to use `assert_equal(%<arguments>s)`?'
         RESTRICT_ON_SEND = %i[assert].freeze
+        MESSAGE_VARIABLES = %w[message msg].freeze
 
         def_node_matcher :assert_with_two_arguments?, <<~PATTERN
           (send nil? :assert $_ $_)
@@ -30,7 +36,7 @@ module RuboCop
 
         def on_send(node)
           assert_with_two_arguments?(node) do |_expected, message|
-            return if message.str_type? || message.dstr_type?
+            return if message.str_type? || message.dstr_type? || MESSAGE_VARIABLES.include?(message.source)
 
             arguments = node.arguments.map(&:source).join(', ')
             add_offense(node, message: format(MSG, arguments: arguments))

--- a/test/rubocop/cop/minitest/assert_with_expected_argument_test.rb
+++ b/test/rubocop/cop/minitest/assert_with_expected_argument_test.rb
@@ -47,6 +47,26 @@ class AssertWithExpectedArgumentTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_when_second_argument_is_a_variable_named_message
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert([], message)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_second_argument_is_a_variable_named_msg
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert([], msg)
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_second_argument_is_an_interpolated_string
     assert_no_offenses(<<~'RUBY')
       class FooTest < Minitest::Test


### PR DESCRIPTION
Fixes #206.

This PR makes `Minitest/AssertWithExpectedArgument` aware of message variable.

The second argument to the `assert` method named `message` and `msg` is allowed. Because their names are inferred as message arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
