### PR TITLE
[Fix #209] Mark `Minitest/AssertTruthy` as unsafe autocorrection

### DIFF
--- a/changelog/change_mark_minitest_assert_truthy_as_unsafe_autocorrection.md
+++ b/changelog/change_mark_minitest_assert_truthy_as_unsafe_autocorrection.md
@@ -1,0 +1,1 @@
+* [#209](https://github.com/rubocop/rubocop-minitest/issues/209): Mark `Minitest/AssertTruthy` as unsafe autocorrection. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -103,7 +103,9 @@ Minitest/AssertTruthy:
   Description: 'This cop enforces the test to use `assert(actual)` instead of using `assert_equal(true, actual)`.'
   StyleGuide: 'https://minitest.rubystyle.guide#assert-truthy'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.2'
+  VersionChanged: '<<next>>'
 
 Minitest/AssertWithExpectedArgument:
   Description: 'This cop tries to detect when a user accidentally used `assert` when they meant to use `assert_equal`.'

--- a/lib/rubocop/cop/minitest/assert_truthy.rb
+++ b/lib/rubocop/cop/minitest/assert_truthy.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Minitest
       # Enforces the test to use `assert(actual)` instead of using `assert_equal(true, actual)`.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because true might be expected instead of truthy.
+      #
       # @example
       #   # bad
       #   assert_equal(true, actual)


### PR DESCRIPTION
Fixes #209.

This PR marks `Minitest/AssertTruthy` as unsafe autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
