### PR TITLE
[Fix #210] Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethodsTest`

### DIFF
--- a/changelog/fix_a_false_positive_for_minitest_empty_line_before_assertion_methods.md
+++ b/changelog/fix_a_false_positive_for_minitest_empty_line_before_assertion_methods.md
@@ -1,0 +1,1 @@
+* [#210](https://github.com/rubocop/rubocop-minitest/issues/210): Fix a false positive for `Minitest/EmptyLineBeforeAssertionMethodsTest` when using assertion method with block arg before other assertion method. ([@koic][])

--- a/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
+++ b/lib/rubocop/cop/minitest/empty_line_before_assertion_methods.rb
@@ -53,7 +53,7 @@ module RuboCop
           return true if !previous_line_node.is_a?(RuboCop::AST::Node) ||
                          previous_line_node.args_type? || node.parent.basic_conditional?
 
-          previous_line_node.send_type? && assertion_method?(previous_line_node)
+          assertion_method?(previous_line_node)
         end
 
         def use_heredoc_argument?(node)

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -78,7 +78,7 @@ module RuboCop
       end
 
       def assertion_method?(node)
-        return false unless node.send_type?
+        return false if !node.send_type? && !node.block_type?
 
         ASSERTION_PREFIXES.any? do |prefix|
           method_name = node.method_name

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -395,4 +395,15 @@ class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assert_raises_with_block_arg_before_assertion_method
+    assert_no_offenses(<<~RUBY)
+      def test_do_something
+        assert_raises(CustomError) do
+          do_something
+        end
+        assert(thing)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #210.

This PR fixes a false positive for `Minitest/EmptyLineBeforeAssertionMethodsTest` when using assertion method with block arg before other assertion method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
