### PR TITLE
[Fix #115] Disable autocorrect on Minitest/TestMethodName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#xxx](https://github.com/rubocop/rubocop-minitest/pull/xxx): Do not autocorrect for `Minitest/TestMethodName`. ([@jamiemccarthy][])
+
 ## 0.25.1 (2022-12-25)
 
 ### Changes
@@ -398,3 +402,4 @@
 [@r7kamura]: https://github.com/r7kamura
 [@rwstauner]: https://github.com/rwstauner
 [@ryanquanz]: https://github.com/ryanquanz
+[@jamiemccarthy]: https://github.com/jamiemccarthy

--- a/lib/rubocop/cop/minitest/test_method_name.rb
+++ b/lib/rubocop/cop/minitest/test_method_name.rb
@@ -30,7 +30,6 @@ module RuboCop
       class TestMethodName < Base
         include MinitestExplorationHelpers
         include DefNode
-        extend AutoCorrector
 
         MSG = 'Test method name should start with `test_` prefix.'
 
@@ -40,11 +39,7 @@ module RuboCop
           class_elements(class_node).each do |node|
             next unless offense?(node)
 
-            test_method_name = node.loc.name
-
-            add_offense(test_method_name) do |corrector|
-              corrector.replace(test_method_name, "test_#{node.method_name}")
-            end
+            add_offense(node.loc.name)
           end
         end
 

--- a/test/rubocop/cop/minitest/test_method_name_test.rb
+++ b/test/rubocop/cop/minitest/test_method_name_test.rb
@@ -16,18 +16,6 @@ class TestMethodNameTest < Minitest::Test
         end
       end
     RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_equal(expected, actual)
-        end
-
-        def test_do_something_else
-          assert_equal(expected, actual)
-        end
-      end
-    RUBY
   end
 
   def test_registers_offense_when_test_method_without_prefix_with_multiple_assertions
@@ -40,20 +28,6 @@ class TestMethodNameTest < Minitest::Test
 
         def do_something_else
             ^^^^^^^^^^^^^^^^^ Test method name should start with `test_` prefix.
-          assert_equal(expected, actual)
-          assert_equal expected, actual
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_equal(expected, actual)
-          assert_equal expected, actual
-        end
-
-        def test_do_something_else
           assert_equal(expected, actual)
           assert_equal expected, actual
         end


### PR DESCRIPTION
I would suggest that #115 remains valid and that #116 did not go far enough in fixing autocorrect for `Minitest/TestMethodName`. I submit that autocorrect should be removed entirely. This PR is intended to do that.

This test is valuable. It enforces a desirable behavior. It's a best practice to not proliferate methods in test classes.

But although it may not be a best practice, it's legitimate behavior for a test class to define a zero-or-more-arguments method that does not begin with `test_` and that makes assertions (possibly based on instance variables or helper methods). This test should catch and flag that behavior.

This test has no way of knowing whether they are accidentally-misnamed methods, or probably-misguided helper methods. If they are helper methods they should be flagged but definitely not renamed.

Even if they are misnamed, renaming them may not be appropriate. If I typoed my method as `tset_foo`, renaming it to `test_tset_foo` is more confusing than helpful.

My company's monolith ended up having six or eight methods that were flagged by this test. Some were just utility methods (providing a params hash). Several were methods that DRYed up our test suite (`assert_permission_redirect!`, `assert_profile_updated`, `assert_has_collection`) referencing instance variables or helper methods. The flagging is helpful, but renaming them would be inappropriate.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
