### PR TITLE
Fix TestFileName error for empty files

### DIFF
--- a/changelog/fix_test_file_name_error_for_empty_files.md
+++ b/changelog/fix_test_file_name_error_for_empty_files.md
@@ -1,0 +1,1 @@
+* [#225](https://github.com/rubocop/rubocop-minitest/issues/225): Fix error in `Minitest/TestFileName` when checking empty files. ([@coding-chimp][])

--- a/lib/rubocop/cop/minitest/test_file_name.rb
+++ b/lib/rubocop/cop/minitest/test_file_name.rb
@@ -29,6 +29,7 @@ module RuboCop
         private
 
         def test_file?(node)
+          return false unless node
           return true if node.class_type? && test_class?(node)
 
           node.each_descendant(:class).any? { |class_node| test_class?(class_node) }

--- a/test/rubocop/cop/minitest/test_file_name_test.rb
+++ b/test/rubocop/cop/minitest/test_file_name_test.rb
@@ -44,4 +44,8 @@ class TestFileNameTest < Minitest::Test
       class Foo; end
     RUBY
   end
+
+  def test_does_not_register_offense_files_without_classes
+    assert_no_offenses('', 'lib/foo.rb')
+  end
 end


### PR DESCRIPTION
Fixes #225.

Ensures the new TestFileName cop does not error when encountering empty files. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
