### PR TITLE
[Fix #225] Fix an error for `Minitest/TestFileName`

### DIFF
--- a/changelog/fix_an_error_for_minitest_test_file_name.md
+++ b/changelog/fix_an_error_for_minitest_test_file_name.md
@@ -1,0 +1,1 @@
+* [#225](https://github.com/rubocop/rubocop-minitest/issues/225): Fix an error for `Minitest/TestFileName` when using empty file. ([@koic][])

--- a/lib/rubocop/cop/minitest/test_file_name.rb
+++ b/lib/rubocop/cop/minitest/test_file_name.rb
@@ -21,7 +21,8 @@ module RuboCop
         MSG = 'Test file path should start with `test_` or end with `_test.rb`.'
 
         def on_new_investigation
-          return unless test_file?(processed_source.ast)
+          return unless (ast = processed_source.ast)
+          return unless test_file?(ast)
 
           add_global_offense(MSG) unless valid_file_name?
         end

--- a/test/rubocop/cop/minitest/test_file_name_test.rb
+++ b/test/rubocop/cop/minitest/test_file_name_test.rb
@@ -44,4 +44,8 @@ class TestFileNameTest < Minitest::Test
       class Foo; end
     RUBY
   end
+
+  def test_does_not_register_offense_for_empty_file
+    assert_no_offenses('', 'lib/foo.rb')
+  end
 end


### PR DESCRIPTION
Fixes #225.

This PR fixes an error for `Minitest/TestFileName` when using empty file.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
