### PR TITLE
Remove duplication from `TestMethodName` cop

### DIFF
--- a/lib/rubocop/cop/minitest/test_method_name.rb
+++ b/lib/rubocop/cop/minitest/test_method_name.rb
@@ -37,7 +37,7 @@ module RuboCop
         def on_class(class_node)
           return unless test_class?(class_node)
 
-          class_elements(class_node).each do |node|
+          class_def_nodes(class_node).each do |node|
             next unless offense?(node)
 
             test_method_name = node.loc.name
@@ -49,17 +49,6 @@ module RuboCop
         end
 
         private
-
-        def class_elements(class_node)
-          class_def = class_node.body
-          return [] unless class_def
-
-          if class_def.def_type?
-            [class_def]
-          else
-            class_def.each_child_node(:def).to_a
-          end
-        end
 
         def offense?(node)
           return false if assertions(node).none?


### PR DESCRIPTION
Removed method just duplicates the existing method from `MinitestExplorationHelpers` module.

I have seen similar patterns a few times at least in rubocop itself (for extracting methods; macros; methods and macros; class method nodes; etc from the class nodes), so wondering if its worth extracting it into `rubocop-ast` in the future.