### PR TITLE
Do not treat `test_` methods with arguments as test methods

### DIFF
--- a/changelog/change_what_is_considered_a_test_case.md
+++ b/changelog/change_what_is_considered_a_test_case.md
@@ -1,0 +1,1 @@
+* [#231](https://github.com/rubocop/rubocop-minitest/pull/231): Change what is considered a test case by `rubocop-minitest` (`public` method without arguments with `test_` name prefix). ([@fatkodima][])

--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -77,6 +77,7 @@ module RuboCop
 
       def setup
         cop_name = self.class.to_s.delete_suffix('Test')
+        return unless RuboCop::Cop::Minitest.const_defined?(cop_name)
 
         @cop = RuboCop::Cop::Minitest.const_get(cop_name).new
       end

--- a/test/rubocop/cop/mixin/minitest_exploration_helpers_test.rb
+++ b/test/rubocop/cop/mixin/minitest_exploration_helpers_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MinitestExplorationHelpersTest < Minitest::Test
+  module Helper
+    extend RuboCop::Cop::MinitestExplorationHelpers
+    class << self
+      public :test_case?
+    end
+  end
+
+  SOURCE = <<~RUBY
+    class FooTest < Minitest::Test
+      def not_test_case; end
+      def test_with_arguments(arg); end
+      def test_public; end
+
+      protected
+      def test_protected; end
+
+      private
+      def test_private; end
+    end
+  RUBY
+
+  def test_test_case_returns_true_for_test_case
+    assert Helper.test_case?(method_node(:test_public))
+  end
+
+  def test_test_case_returns_false_for_hidden_test_methods
+    refute Helper.test_case?(method_node(:test_protected))
+    refute Helper.test_case?(method_node(:test_private))
+  end
+
+  def test_test_case_returns_false_for_non_test_methods
+    refute Helper.test_case?(method_node(:non_test_case))
+  end
+
+  def test_test_case_returns_false_for_test_methods_with_arguments
+    refute Helper.test_case?(method_node(:test_with_arguments))
+  end
+
+  private
+
+  def method_node(method_name)
+    class_node = parse_source!(SOURCE).ast
+    class_node.body.each_child_node(:def).find { |def_node| def_node.method?(method_name) }
+  end
+end


### PR DESCRIPTION
While testing https://github.com/rubocop/rubocop-minitest/pull/229 on https://github.com/openstreetmap/openstreetmap-website, it detected this - https://github.com/openstreetmap/openstreetmap-website/blob/b278bc06ef720af8c21c99659c4d70334384c386/test/integration/oauth2_test.rb#L141, because `rubocop-minitest` detects all class methods starting with `test_` as test cases. But we should ignore such methods having arguments.