### PR TITLE
Mark `Minitest/RefuteFalse` as unsafe

### DIFF
--- a/changelog/change_mark_minitest_refute_false_as_unsafe.md
+++ b/changelog/change_mark_minitest_refute_false_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#233](https://github.com/rubocop/rubocop-minitest/pull/233): Mark `Minitest/RefuteFalse` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -191,7 +191,9 @@ Minitest/RefuteFalse:
   Description: 'Check if your test uses `refute(actual)` instead of `assert_equal(false, actual)`.'
   StyleGuide: 'https://minitest.rubystyle.guide#refute-false'
   Enabled: true
+  Safe: false
   VersionAdded: '0.3'
+  VersionChanged: '<<next>>'
 
 Minitest/RefuteInDelta:
   Description: 'This cop enforces the test to use `refute_in_delta` instead of using `refute_equal` to compare floats.'

--- a/lib/rubocop/cop/minitest/refute_false.rb
+++ b/lib/rubocop/cop/minitest/refute_false.rb
@@ -5,6 +5,16 @@ module RuboCop
     module Minitest
       # Enforces the use of `refute(object)` over `assert_equal(false, object)`.
       #
+      # @safety
+      #   This cop is unsafe because it cannot detect failure when second argument is `nil`.
+      #   False positives cannot be prevented when this is a variable or method return value.
+      #
+      #   [source,ruby]
+      #   ----
+      #   assert_equal(false, nil) # failure
+      #   refute(nil)              # success
+      #   ----
+      #
       # @example
       #   # bad
       #   assert_equal(false, actual)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-minitest/issues/209#issuecomment-1385071429

This PR marks `Minitest/RefuteFalse` as unsafe. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
