### PR TITLE
Mark `Minitest/AssertTruthy` as unsafe

### DIFF
--- a/changelog/change_mark_minitest_assert_truthy_as_unsafe.md
+++ b/changelog/change_mark_minitest_assert_truthy_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#234](https://github.com/rubocop/rubocop-minitest/pull/234): Mark `Minitest/AssertTruthy` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -111,9 +111,9 @@ Minitest/AssertTruthy:
   Description: 'This cop enforces the test to use `assert(actual)` instead of using `assert_equal(true, actual)`.'
   StyleGuide: 'https://minitest.rubystyle.guide#assert-truthy'
   Enabled: true
-  SafeAutoCorrect: false
+  Safe: false
   VersionAdded: '0.2'
-  VersionChanged: '0.26'
+  VersionChanged: '<<next>>'
 
 Minitest/AssertWithExpectedArgument:
   Description: 'This cop tries to detect when a user accidentally used `assert` when they meant to use `assert_equal`.'

--- a/lib/rubocop/cop/minitest/assert_truthy.rb
+++ b/lib/rubocop/cop/minitest/assert_truthy.rb
@@ -6,7 +6,14 @@ module RuboCop
       # Enforces the test to use `assert(actual)` instead of using `assert_equal(true, actual)`.
       #
       # @safety
-      #   This cop's autocorrection is unsafe because true might be expected instead of truthy.
+      #   This cop is unsafe because true might be expected instead of truthy.
+      #   False positives cannot be prevented when this is a variable or method return value.
+      #
+      #   [source,ruby]
+      #   ----
+      #   assert_equal(true, 'truthy') # failure
+      #   assert('truthy')             # success
+      #   ----
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR marks `Minitest/AssertTruthy` as unsafe. As with #233, this is a false positive issue than autocorrection compatibility.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
