### PR TITLE
Fix a false positive for `Minitest/UselessAssertion` when using command execution

### DIFF
--- a/changelog/fix_useless_assertion_for_commands.md
+++ b/changelog/fix_useless_assertion_for_commands.md
@@ -1,0 +1,1 @@
+* [#237](https://github.com/rubocop/rubocop-minitest/pull/237): Fix a false positive for `Minitest/UselessAssertion` when using command execution. ([@fatkodima][])

--- a/lib/rubocop/cop/minitest/useless_assertion.rb
+++ b/lib/rubocop/cop/minitest/useless_assertion.rb
@@ -46,7 +46,7 @@ module RuboCop
 
           case node.method_name
           when *SINGLE_ASSERTION_ARGUMENT_METHODS
-            actual.nil? && expected&.literal?
+            actual.nil? && expected&.literal? && !expected.xstr_type?
           when *TWO_ASSERTION_ARGUMENTS_METHODS
             return false unless expected || actual
             return false if expected.source != actual.source

--- a/test/rubocop/cop/minitest/useless_assertion_test.rb
+++ b/test/rubocop/cop/minitest/useless_assertion_test.rb
@@ -44,6 +44,13 @@ class UselessAssertionTest < Minitest::Test
         #{matcher} false, "My message"
       RUBY
     end
+
+    define_method("test_#{matcher}_no_offenses_when_executing_command") do
+      assert_no_offenses(<<~RUBY)
+        #{matcher} `ls`
+        #{matcher} %x{ls}
+      RUBY
+    end
   end
 
   %i[


### PR DESCRIPTION
Found a false positive: 
```ruby
assert_empty(`bundle exec yard --no-save --no-output --no-stats`)
```
https://github.com/fatkodima/sidekiq-iteration/blob/81453f8a5586367ba69c80aeea960fe824b76c40/test/documentation_test.rb#L8

