### PR TITLE
Support `it`/`test` testing blocks as test cases

### DIFF
--- a/changelog/new_accept_it_test_block_as_testcase.md
+++ b/changelog/new_accept_it_test_block_as_testcase.md
@@ -1,0 +1,1 @@
+* [#238](https://github.com/rubocop/rubocop-minitest/pull/238): Support `it`/`test` testing blocks as test cases. ([@fatkodima][])

--- a/lib/rubocop/cop/minitest/assert_output.rb
+++ b/lib/rubocop/cop/minitest/assert_output.rb
@@ -36,8 +36,7 @@ module RuboCop
         private
 
         def find_test_case(node)
-          def_ancestor = node.each_ancestor(:def).first
-          def_ancestor if test_case?(def_ancestor)
+          node.each_ancestor.find { |ancestor| test_case?(ancestor) }
         end
 
         def references_gvar?(assertion, gvar_name)

--- a/test/rubocop/cop/minitest/assert_output_test.rb
+++ b/test/rubocop/cop/minitest/assert_output_test.rb
@@ -17,6 +17,22 @@ class AssertOutputTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_mutating_output_global_variable_in_it_block_form
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        describe Foo do
+          it "does something" do
+            $stdout = StringIO.new
+            puts object.method
+            $stdout.rewind
+            assert_match expected, $stdout.read
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `assert_output` instead of mutating $stdout.
+          end
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_not_inside_test_case
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-minitest/pull/203.

That PR implemented support for `it`/`test` to be selected when selecting test cases, but the check for individual test cases (`test_case?` method) was missed to be extended.