### PR TITLE
Make `Minitest/GlobalExpectations` aware of pattern matchers

### DIFF
--- a/changelog/new_make_minitest_global_expectations_aware_of_pattern_matchers.md
+++ b/changelog/new_make_minitest_global_expectations_aware_of_pattern_matchers.md
@@ -1,0 +1,1 @@
+* [#244](https://github.com/rubocop/rubocop-minitest/pull/244): Make `Minitest/GlobalExpectations` aware of `must_pattern_match` and `wont_pattern_match` matchers. ([@koic][])

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -96,7 +96,9 @@ module RuboCop
           wont_be_kind_of wont_match wont_be_nil wont_be wont_respond_to wont_be_same_as
         ].freeze
 
-        BLOCK_MATCHERS = %i[must_output must_raise must_be_silent must_throw].freeze
+        BLOCK_MATCHERS = %i[
+          must_output must_pattern_match must_raise must_be_silent must_throw wont_pattern_match
+        ].freeze
 
         RESTRICT_ON_SEND = VALUE_MATCHERS + BLOCK_MATCHERS
 


### PR DESCRIPTION
Follow up https://github.com/minitest/minitest/commit/0c44f4e

This PR makes `Minitest/GlobalExpectations` aware of `must_pattern_match` and `wont_pattern_match` matchers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
