### PR TITLE
Prevent breaking change for assertion message in test

### DIFF
--- a/changelog/fix_prevent_breaking_change_for_assertion_message_in_test.md
+++ b/changelog/fix_prevent_breaking_change_for_assertion_message_in_test.md
@@ -1,0 +1,1 @@
+* [#247](https://github.com/rubocop/rubocop-minitest/pull/247): Prevent breaking change for assertion message in test. ([@koic][])

--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -79,7 +79,7 @@ module RuboCop
         cop_name = self.class.to_s.delete_suffix('Test')
         return unless RuboCop::Cop::Minitest.const_defined?(cop_name)
 
-        @cop = RuboCop::Cop::Minitest.const_get(cop_name).new
+        @cop = RuboCop::Cop::Minitest.const_get(cop_name).new(configuration)
       end
 
       def format_offense(source, **replacements)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11729.

This PR prevents breaking change for assertion message in test. e.g.

```console
% bundle exec ruby -Itest test/rubocop/cop/minitest/lifecycle_hooks_order_test.rb
(snip)

Fabulous run in 0.075080s, 93.2339 runs/s, 93.2339 assertions/s.

  1) Failure:
LifecycleHooksOrderTest#test_registers_offense_when_hooks_are_not_before_test_cases [test/rubocop/cop/minitest/lifecycle_hooks_order_test.rb:62]:
--- expected
+++ actual
@@ -4,7 +4,7 @@
   end

   def setup; end
-  ^^^^^^^^^^^^^^ `setup` is supposed to appear before `test_something`.
+  ^^^^^^^^^^^^^^ Minitest/LifecycleHooksOrder: `setup` is supposed to appear before `test_something`.
   def teardown; end
 end
 "
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
