### PR TITLE
Handle assertions in conditionals branches in `Minitest/MultipleAssertions` cop

### DIFF
--- a/changelog/change_handle_assertions_in_conditionals.md
+++ b/changelog/change_handle_assertions_in_conditionals.md
@@ -1,0 +1,1 @@
+* [#249](https://github.com/rubocop/rubocop-minitest/pull/249): Handle assertions in conditionals branches in `Minitest/MultipleAssertions` cop. ([@fatkodima][])

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -100,7 +100,7 @@ module RuboCop
       end
 
       def assertion_method?(node)
-        return false if !node.send_type? && !node.block_type?
+        return false if !node.send_type? && !node.block_type? && !node.numblock_type?
 
         ASSERTION_PREFIXES.any? do |prefix|
           method_name = node.method_name


### PR DESCRIPTION
These changes are to allow to have assertions like:
```ruby
def test_foo
  if ActiveRecord::VERSION >= "7.0"
    assert ActiveRecord.old_foo_method(1, 2)
  else
    assert ActiveRecord.new_foo_method(1, 2)
  end 
end
```

A recent example that inspired this - https://github.com/ixti/sidekiq-throttled/pull/142/files#diff-87c291ea2af263111982285d3dea3083faa62260cc6080cc5396f4bf82a37cf4R22-R27 (it is using rspec, but it does not matter)