### PR TITLE
Use test-queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'minitest-proveit'
 gem 'rake'
 gem 'rubocop', github: 'rubocop/rubocop'
 gem 'rubocop-performance', '~> 1.15.0'
+gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 local_gemfile = File.expand_path('Gemfile.local', __dir__)

--- a/Rakefile
+++ b/Rakefile
@@ -19,10 +19,9 @@ require 'rubocop/rake_task'
 require 'rake/testtask'
 require_relative 'lib/rubocop/cop/generator'
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb']
+desc 'Run tests'
+task :test do
+  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}")
 end
 
 desc 'Run RuboCop over itself'


### PR DESCRIPTION
https://github.com/tmm1/test-queue/pull/108 has been released, So RuboCop Minitest can be accelerated for testing by test-queue.

1.5x speedup in an environment:

## Before

```console
% bundle exec rake test
Run options: --seed 61017

# Running:
(snip)

Fabulous run in 6.712563s, 348.0042 runs/s, 1010.7913 assertions/s.

2336 runs, 6785 assertions, 0 failures, 0 errors, 0 skips
```

## After

```console
% bunlde exec rake test
Starting test-queue master (/tmp/test_queue_12114_1480.sock)

==> Summary (16 workers in 4.2143s)

    [ 1]      470 runs, 900 assertions, 0 failures, 0 errors, 0 skips         1 suites in 4.2041s      (pid 12117 exit 0 )
    [ 2]      470 runs, 820 assertions, 0 failures, 0 errors, 0 skips         1 suites in 4.2043s      (pid 12118 exit 0 )
    [ 3]        81 runs, 81 assertions, 0 failures, 0 errors, 0 skips         1 suites in 4.2042s      (pid 12119 exit 0 )
    [ 4]      470 runs, 900 assertions, 0 failures, 0 errors, 0 skips         1 suites in 4.2062s      (pid 12120 exit 0 )
    [ 5]      470 runs, 900 assertions, 0 failures, 0 errors, 0 skips         1 suites in 4.2063s      (pid 12121 exit 0 )
    [ 6]        23 runs, 25 assertions, 0 failures, 0 errors, 0 skips         2 suites in 4.2062s      (pid 12122 exit 0 )
    [ 7]        35 runs, 52 assertions, 0 failures, 0 errors, 0 skips         3 suites in 4.2059s      (pid 12123 exit 0 )
    [ 8]        31 runs, 55 assertions, 0 failures, 0 errors, 0 skips         3 suites in 4.2058s      (pid 12124 exit 0 )
    [ 9]        37 runs, 62 assertions, 0 failures, 0 errors, 0 skips         4 suites in 4.2055s      (pid 12125 exit 0 )
    [10]        34 runs, 45 assertions, 0 failures, 0 errors, 0 skips         5 suites in 4.2051s      (pid 12126 exit 0 )
    [11]        38 runs, 52 assertions, 0 failures, 0 errors, 0 skips         6 suites in 4.2038s      (pid 12127 exit 0 )
    [12]        34 runs, 46 assertions, 0 failures, 0 errors, 0 skips         5 suites in 4.2031s      (pid 12128 exit 0 )
    [13]      39 runs, 2690 assertions, 0 failures, 0 errors, 0 skips         5 suites in 4.2019s      (pid 12129 exit 0 )
    [14]        34 runs, 53 assertions, 0 failures, 0 errors, 0 skips         5 suites in 4.2007s      (pid 12130 exit 0 )
    [15]        34 runs, 57 assertions, 0 failures, 0 errors, 0 skips         6 suites in 4.1994s      (pid 12131 exit 0 )
    [16]        36 runs, 47 assertions, 0 failures, 0 errors, 0 skips         5 suites in 4.1980s      (pid 12132 exit 0 )
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
