### PR TITLE
[Fix #256] Fix a false positive for `Minitest/RefuteEqual`

### DIFF
--- a/changelog/fix_a_false_positive_for_minitest_refute_equal.md
+++ b/changelog/fix_a_false_positive_for_minitest_refute_equal.md
@@ -1,0 +1,1 @@
+* [#256](https://github.com/rubocop/rubocop-minitest/issues/256): Fix a false positive for `Minitest/RefuteEqual` when `assert(!expected == actual)`. ([@koic][])

--- a/lib/rubocop/cop/minitest/refute_equal.rb
+++ b/lib/rubocop/cop/minitest/refute_equal.rb
@@ -9,7 +9,6 @@ module RuboCop
       # @example
       #   # bad
       #   assert("rubocop-minitest" != actual)
-      #   assert(! "rubocop-minitest" == actual)
       #
       #   # good
       #   refute_equal("rubocop-minitest", actual)
@@ -22,7 +21,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[assert].freeze
 
         def_node_matcher :assert_not_equal, <<~PATTERN
-          (send nil? :assert {(send $_ :!= $_) (send (send $_ :! ) :== $_) } $... )
+          (send nil? :assert (send $_ :!= $_) $... )
         PATTERN
 
         def on_send(node)

--- a/test/rubocop/cop/minitest/refute_equal_test.rb
+++ b/test/rubocop/cop/minitest/refute_equal_test.rb
@@ -79,61 +79,31 @@ class RefuteEqualTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_negate_equals
-    assert_offense(<<~RUBY)
+  def test_does_not_register_offense_when_using_negate_equals
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(! 'rubocop-minitest' == object)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_equal('rubocop-minitest', object)
+          assert(!'rubocop-minitest' == object)
         end
       end
     RUBY
   end
 
-  def test_registers_offense_when_using_negate_equals_with_message
-    assert_offense(<<~RUBY)
+  def test_does_not_register_offense_when_using_negate_equals_with_message
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(! 'rubocop-minitest' == object, 'message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', object, 'message')`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_equal('rubocop-minitest', object, 'message')
+          assert(!'rubocop-minitest' == object, 'message')
         end
       end
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_equal_operator_with_heredoc_message
-    assert_offense(<<~RUBY)
+  def test_does_not_register_offense_when_using_refute_equal_operator_with_heredoc_message
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert(!'rubocop-minitest' == actual, <<~MESSAGE
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual, <<~MESSAGE)`.
-            message
-          MESSAGE
-          )
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_equal('rubocop-minitest', actual, <<~MESSAGE
             message
           MESSAGE
           )


### PR DESCRIPTION
Fixes #256.

This PR fixes a false positive for `Minitest/RefuteEqual` when `assert(!expected == actual)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
