### PR TITLE
[Fix #261] Fix an error for `Minitest/AssertOperator`

### DIFF
--- a/changelog/fix_an_error_for_assert_operator.md
+++ b/changelog/fix_an_error_for_assert_operator.md
@@ -1,0 +1,1 @@
+* [#261](https://github.com/rubocop/rubocop-minitest/issues/261): Fix an error for `Minitest/AssertOperator` and `Minitest/RefuteOperator` when using variable argument. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_operator.rb
+++ b/lib/rubocop/cop/minitest/assert_operator.rb
@@ -20,7 +20,8 @@ module RuboCop
         RESTRICT_ON_SEND = %i[assert].freeze
 
         def on_send(node)
-          return unless node.first_argument.operator_method?
+          first_argument = node.first_argument
+          return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
 
           new_arguments = build_new_arguments(node)
 

--- a/lib/rubocop/cop/minitest/refute_operator.rb
+++ b/lib/rubocop/cop/minitest/refute_operator.rb
@@ -20,7 +20,8 @@ module RuboCop
         RESTRICT_ON_SEND = %i[refute].freeze
 
         def on_send(node)
-          return unless node.first_argument.operator_method?
+          first_argument = node.first_argument
+          return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
 
           new_arguments = build_new_arguments(node)
 

--- a/test/rubocop/cop/minitest/assert_operator_test.rb
+++ b/test/rubocop/cop/minitest/assert_operator_test.rb
@@ -69,4 +69,16 @@ class AssertOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assert_with_variable
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          var = do_something
+
+          assert(var)
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/refute_operator_test.rb
+++ b/test/rubocop/cop/minitest/refute_operator_test.rb
@@ -69,4 +69,16 @@ class RefuteOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_refute_with_variable
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          var = do_something
+
+          refute(var)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #261.

This PR fixes an error for `Minitest/AssertOperator` and `Minitest/RefuteOperator` when using variable argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
