### PR TITLE
Fix an error for `Minitest/AssertOperator` and `Minitest/RefuteOperator`

### DIFF
--- a/changelog/fix_an_error_for_assert_operator_and_refute_operator.md
+++ b/changelog/fix_an_error_for_assert_operator_and_refute_operator.md
@@ -1,0 +1,1 @@
+* [#263](https://github.com/rubocop/rubocop-minitest/pull/263): Fix an error for `Minitest/AssertOperator` and `Minitest/RefuteOperator` when using unary operation argument. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_operator.rb
+++ b/lib/rubocop/cop/minitest/assert_operator.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           first_argument = node.first_argument
-          return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
+          return unless first_argument.respond_to?(:binary_operation?) && first_argument.binary_operation?
 
           operator = first_argument.to_a[1]
           return if ALLOWED_OPERATORS.include?(operator)

--- a/lib/rubocop/cop/minitest/refute_operator.rb
+++ b/lib/rubocop/cop/minitest/refute_operator.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           first_argument = node.first_argument
-          return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
+          return unless first_argument.respond_to?(:binary_operation?) && first_argument.binary_operation?
 
           operator = first_argument.to_a[1]
           return if ALLOWED_OPERATORS.include?(operator)

--- a/test/rubocop/cop/minitest/assert_operator_test.rb
+++ b/test/rubocop/cop/minitest/assert_operator_test.rb
@@ -91,4 +91,14 @@ class AssertOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_assert_with_unary_operation
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(-x)
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/refute_operator_test.rb
+++ b/test/rubocop/cop/minitest/refute_operator_test.rb
@@ -91,4 +91,14 @@ class RefuteOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_refute_with_unary_operation
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(-x)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes an error for `Minitest/AssertOperator` and `Minitest/RefuteOperator` when using unary operation argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
