### PR TITLE
Update AssertOperator and RefuteOperator to allow :[]

### DIFF
--- a/lib/rubocop/cop/minitest/assert_operator.rb
+++ b/lib/rubocop/cop/minitest/assert_operator.rb
@@ -18,10 +18,14 @@ module RuboCop
 
         MSG = 'Prefer using `assert_operator(%<new_arguments>s)`.'
         RESTRICT_ON_SEND = %i[assert].freeze
+        ALLOWED_OPERATORS = [:[]].freeze
 
         def on_send(node)
           first_argument = node.first_argument
           return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
+
+          operator = first_argument.to_a[1]
+          return if ALLOWED_OPERATORS.include?(operator)
 
           new_arguments = build_new_arguments(node)
 

--- a/lib/rubocop/cop/minitest/refute_operator.rb
+++ b/lib/rubocop/cop/minitest/refute_operator.rb
@@ -18,10 +18,14 @@ module RuboCop
 
         MSG = 'Prefer using `refute_operator(%<new_arguments>s)`.'
         RESTRICT_ON_SEND = %i[refute].freeze
+        ALLOWED_OPERATORS = [:[]].freeze
 
         def on_send(node)
           first_argument = node.first_argument
           return unless first_argument.respond_to?(:operator_method?) && first_argument.operator_method?
+
+          operator = first_argument.to_a[1]
+          return if ALLOWED_OPERATORS.include?(operator)
 
           new_arguments = build_new_arguments(node)
 

--- a/test/rubocop/cop/minitest/assert_operator_test.rb
+++ b/test/rubocop/cop/minitest/assert_operator_test.rb
@@ -81,4 +81,14 @@ class AssertOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_consider_brackets_to_be_an_offense
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(array_of_booleans[42])
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/refute_operator_test.rb
+++ b/test/rubocop/cop/minitest/refute_operator_test.rb
@@ -81,4 +81,14 @@ class RefuteOperatorTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_consider_brackets_to_be_an_offense
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(array_of_booleans[42])
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Update the `AssertOperator` and `RefuteOperator` cops to allow `:[]`

The rubocop style guide prefers `assert` and `refute` for testing booleans. If I have an array of booleans, then I want to be able to use this style:

```
  def test_my_array
    assert(array_of_bools[0])
    refute(array_of_bools[1])
  end
```

This PR is suggested by an [actual test in the Nokogiri suite](https://github.com/sparklemotion/nokogiri/blob/main/test/xml/test_reader.rb#L699-L700) which collects boolean values from Nokogiri::Reader as it passes through the document, and then checks the values after completing the parsing pass. That test could be rewritten, but I don't personally think it would be made more readable by that rewrite.

Also see https://github.com/rubocop/rubocop-minitest/pull/260#issuecomment-1734520785 which raised the question of whether `:[]` was intentionally a violation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
