### PR TITLE
Make `Minitest/RefuteEqual` aware of `refute(expected == actual)`

### DIFF
--- a/changelog/change_make_minitest_refute_equal_aware_of_refute_equal.md
+++ b/changelog/change_make_minitest_refute_equal_aware_of_refute_equal.md
@@ -1,0 +1,1 @@
+* [#265](https://github.com/rubocop/rubocop-minitest/pull/265): Make `Minitest/RefuteEqual` aware of `refute(expected == actual)`. ([@koic][])

--- a/test/rubocop/cop/minitest/refute_equal_test.rb
+++ b/test/rubocop/cop/minitest/refute_equal_test.rb
@@ -79,6 +79,25 @@ class RefuteEqualTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_equal_operator
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute('rubocop-minitest' == actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_negate_equals
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-minitest/pull/260#issuecomment-1738383900

This PR makes `Minitest/RefuteEqual` aware of `refute(expected == actual)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
