### PR TITLE
Make `Minitest/AssertEqual` aware of `assert_operator`

### DIFF
--- a/changelog/new_make_minitest_assert_equal_aware_of_assert_operator.md
+++ b/changelog/new_make_minitest_assert_equal_aware_of_assert_operator.md
@@ -1,0 +1,1 @@
+* [#266](https://github.com/rubocop/rubocop-minitest/pull/266): Make `Minitest/AssertEqual` aware of `assert_operator`. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_equal.rb
+++ b/lib/rubocop/cop/minitest/assert_equal.rb
@@ -9,14 +9,46 @@ module RuboCop
       # @example
       #   # bad
       #   assert("rubocop-minitest" == actual)
+      #   assert_operator("rubocop-minitest", :==, actual)
       #
       #   # good
       #   assert_equal("rubocop-minitest", actual)
       #
       class AssertEqual < Base
-        extend MinitestCopRule
+        include ArgumentRangeHelper
+        extend AutoCorrector
 
-        define_rule :assert, target_method: :==, preferred_method: :assert_equal
+        MSG = 'Prefer using `assert_equal(%<preferred>s)`.'
+        RESTRICT_ON_SEND = %i[assert assert_operator].freeze
+
+        def_node_matcher :assert_equal, <<~PATTERN
+          {
+            (send nil? :assert (send $_ :== $_) $...)
+            (send nil? :assert_operator $_ (sym :==) $_ $...)
+          }
+        PATTERN
+
+        # rubocop:disable Metrics/AbcSize
+        def on_send(node)
+          assert_equal(node) do |expected, actual, rest_args|
+            basic_arguments = "#{expected.source}, #{actual.source}"
+            preferred = (message_arg = rest_args.first) ? "#{basic_arguments}, #{message_arg.source}" : basic_arguments
+            message = format(MSG, preferred: preferred)
+
+            add_offense(node, message: message) do |corrector|
+              corrector.replace(node.loc.selector, 'assert_equal')
+
+              range = if node.method?(:assert)
+                        node.first_argument
+                      else
+                        node.first_argument.source_range.begin.join(node.arguments[2].source_range.end)
+                      end
+
+              corrector.replace(range, basic_arguments)
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_equal_test.rb
+++ b/test/rubocop/cop/minitest/assert_equal_test.rb
@@ -104,12 +104,12 @@ class AssertEqualTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_equal_in_redundant_parentheses
+  def test_registers_offense_when_using_assert_operator_with_equal_symbol_argument
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(('rubocop-minitest' == actual))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual)`.
+          assert_operator('rubocop-minitest', :==, actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual)`.
         end
       end
     RUBY
@@ -117,7 +117,26 @@ class AssertEqualTest < Minitest::Test
     assert_correction(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert_equal(('rubocop-minitest', actual))
+          assert_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_operator_with_equal_symbol_and_message_argument
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_operator('rubocop-minitest', :==, actual, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal('rubocop-minitest', actual, message)
         end
       end
     RUBY
@@ -128,6 +147,27 @@ class AssertEqualTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_operator_with_negated_equal_symbol_argument
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_operator('rubocop-minitest', :!=, actual)
+        end
+      end
+    RUBY
+  end
+
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_assert_with_equal_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(('rubocop-minitest' == actual))
         end
       end
     RUBY


### PR DESCRIPTION
This PR makes `Minitest/AssertEqual` aware of `assert_operator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
