### PR TITLE
Make `Minitest/RefuteEqual` aware of `assert_operator` and `refute_operator`

### DIFF
--- a/changelog/new_make_minitest_refute_equal_aware_of_assert_operator_and_refute_operator.md
+++ b/changelog/new_make_minitest_refute_equal_aware_of_assert_operator_and_refute_operator.md
@@ -1,0 +1,1 @@
+* [#267](https://github.com/rubocop/rubocop-minitest/pull/267): Make `Minitest/RefuteEqual` aware of `assert_operator` and `refute_operator`. ([@koic][])

--- a/test/rubocop/cop/minitest/refute_equal_test.rb
+++ b/test/rubocop/cop/minitest/refute_equal_test.rb
@@ -79,12 +79,12 @@ class RefuteEqualTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_equal_operator
+  def test_registers_offense_when_using_assert_operator_with_negated_equal_symbol_argument
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          refute('rubocop-minitest' == actual)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual)`.
+          assert_operator('rubocop-minitest', :!=, actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual)`.
         end
       end
     RUBY
@@ -93,6 +93,63 @@ class RefuteEqualTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_operator_with_negated_equal_symbol_and_message_arguments
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_operator('rubocop-minitest', :==, actual, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal('rubocop-minitest', actual, message)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_operator_with_equal_symbol_argument
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_operator('rubocop-minitest', :==, actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_operator_with_equal_symbol_and_message_arguments
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_operator('rubocop-minitest', :==, actual, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_equal('rubocop-minitest', actual, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal('rubocop-minitest', actual, message)
         end
       end
     RUBY
@@ -136,6 +193,26 @@ class RefuteEqualTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_operator_with_equal_symbol_argument
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_operator('rubocop-minitest', :==, actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_operator_with_negated_equal_symbol_argument
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_operator('rubocop-minitest', :!=, actual)
         end
       end
     RUBY


### PR DESCRIPTION
This PR makes `Minitest/RefuteEqual` aware of `assert_operator` and `refute_operator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
