### PR TITLE
Make `Minitest/AssertMatch` aware of `assert_operator`

### DIFF
--- a/changelog/new_make_minitest_assert_match_aware_of_assert_operator.md
+++ b/changelog/new_make_minitest_assert_match_aware_of_assert_operator.md
@@ -1,0 +1,1 @@
+* [#268](https://github.com/rubocop/rubocop-minitest/pull/268): Make `Minitest/AssertMatch` aware of `assert_operator`. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_match.rb
+++ b/lib/rubocop/cop/minitest/assert_match.rb
@@ -11,6 +11,7 @@ module RuboCop
       #   assert(matcher.match(string))
       #   assert(matcher.match?(string))
       #   assert(matcher =~ string)
+      #   assert_operator(matcher, :=~, string)
       #   assert(matcher.match(string), 'message')
       #
       #   # good
@@ -18,10 +19,50 @@ module RuboCop
       #   assert_match(matcher, string, 'message')
       #
       class AssertMatch < Base
-        extend MinitestCopRule
+        include ArgumentRangeHelper
+        extend AutoCorrector
 
-        define_rule :assert, target_method: %i[match match? =~],
-                             preferred_method: :assert_match, inverse: 'regexp_type?'
+        MSG = 'Prefer using `assert_match(%<preferred>s)`.'
+        RESTRICT_ON_SEND = %i[assert assert_operator].freeze
+
+        def_node_matcher :assert_match, <<~PATTERN
+          {
+            (send nil? :assert (send $_ {:match :match? :=~} $_) $...)
+            (send nil? :assert_operator $_ (sym :=~) $_ $...)
+          }
+        PATTERN
+
+        # rubocop:disable Metrics/AbcSize
+        def on_send(node)
+          assert_match(node) do |expected, actual, rest_args|
+            basic_arguments = order_expected_and_actual(expected, actual)
+            preferred = (message_arg = rest_args.first) ? "#{basic_arguments}, #{message_arg.source}" : basic_arguments
+            message = format(MSG, preferred: preferred)
+
+            add_offense(node, message: message) do |corrector|
+              corrector.replace(node.loc.selector, 'assert_match')
+
+              range = if node.method?(:assert)
+                        node.first_argument
+                      else
+                        node.first_argument.source_range.begin.join(node.arguments[2].source_range.end)
+                      end
+
+              corrector.replace(range, basic_arguments)
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        private
+
+        def order_expected_and_actual(expected, actual)
+          if actual.regexp_type?
+            [actual, expected]
+          else
+            [expected, actual]
+          end.map(&:source).join(', ')
+        end
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_match.rb
+++ b/lib/rubocop/cop/minitest/refute_match.rb
@@ -11,6 +11,7 @@ module RuboCop
       #   refute(matcher.match(string))
       #   refute(matcher.match?(string))
       #   refute(matcher =~ string)
+      #   refute_operator(matcher, :=~, string)
       #   refute(matcher.match(string), 'message')
       #
       #   # good

--- a/test/rubocop/cop/minitest/assert_match_test.rb
+++ b/test/rubocop/cop/minitest/assert_match_test.rb
@@ -105,24 +105,35 @@ class AssertMatchTest < Minitest::Test
       RUBY
     end
 
+    # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
     define_method("test_registers_offense_when_using_assert_with_#{matcher}_in_redundant_parentheses") do
-      assert_offense(<<~RUBY, matcher: matcher)
+      assert_no_offenses(<<~RUBY, matcher: matcher)
         class FooTest < Minitest::Test
           def test_do_something
             assert((matcher.#{matcher}(string)))
-            ^^^^^^^^^^^^^^^^^{matcher}^^^^^^^^^^ Prefer using `assert_match(matcher, string)`.
-          end
-        end
-      RUBY
-
-      assert_correction(<<~RUBY)
-        class FooTest < Minitest::Test
-          def test_do_something
-            assert_match((matcher, string))
           end
         end
       RUBY
     end
+  end
+
+  def test_registers_offense_when_using_assert_operator_with_match_operator
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_operator(matcher, :=~, object)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(matcher, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match(matcher, object)
+        end
+      end
+    RUBY
   end
 
   def test_does_not_register_offense_when_using_assert_match
@@ -150,6 +161,16 @@ class AssertMatchTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           assert(matcher&.match)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assert_operator_with_mismatch_operator
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_operator(matcher, :!~, object)
         end
       end
     RUBY


### PR DESCRIPTION
This PR makes `Minitest/AssertMatch` aware of `assert_operator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
