### PR TITLE
Ignore offenses inside redundant parentheses

### DIFF
--- a/changelog/change_ignore_offenses_inside_redundant.md
+++ b/changelog/change_ignore_offenses_inside_redundant.md
@@ -1,0 +1,1 @@
+* [#270](https://github.com/rubocop/rubocop-minitest/pull/270): Ignore offenses inside redundant parentheses. ([@sambostock][])

--- a/lib/rubocop/cop/minitest/assert_empty.rb
+++ b/lib/rubocop/cop/minitest/assert_empty.rb
@@ -22,12 +22,11 @@ module RuboCop
         remove_method :on_send
         def on_send(node)
           return unless node.method?(:assert)
-          return unless (arguments = peel_redundant_parentheses_from(node.arguments))
-          return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:empty?)
-          return unless arguments.first.arguments.empty?
+          return unless node.arguments.first.respond_to?(:method?) && node.arguments.first.method?(:empty?)
+          return unless node.arguments.first.arguments.empty?
 
-          add_offense(node, message: offense_message(arguments)) do |corrector|
-            autocorrect(corrector, node, arguments)
+          add_offense(node, message: offense_message(node.arguments)) do |corrector|
+            autocorrect(corrector, node, node.arguments)
           end
         end
       end

--- a/lib/rubocop/cop/minitest/refute_empty.rb
+++ b/lib/rubocop/cop/minitest/refute_empty.rb
@@ -22,12 +22,11 @@ module RuboCop
         remove_method :on_send
         def on_send(node)
           return unless node.method?(:refute)
-          return unless (arguments = peel_redundant_parentheses_from(node.arguments))
-          return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:empty?)
-          return unless arguments.first.arguments.empty?
+          return unless node.arguments.first.respond_to?(:method?) && node.arguments.first.method?(:empty?)
+          return unless node.arguments.first.arguments.empty?
 
-          add_offense(node, message: offense_message(arguments)) do |corrector|
-            autocorrect(corrector, node, arguments)
+          add_offense(node, message: offense_message(node.arguments)) do |corrector|
+            autocorrect(corrector, node, node.arguments)
           end
         end
       end

--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -66,20 +66,12 @@ class AssertEmptyTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_empty_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_assert_with_empty_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert((somestuff.empty?))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_empty((somestuff))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -66,20 +66,12 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_include_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_assert_with_include_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert((collection.include?(object)))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_includes((collection, object))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/assert_predicate_test.rb
+++ b/test/rubocop/cop/minitest/assert_predicate_test.rb
@@ -64,20 +64,12 @@ class AssertPredicateTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_predicate_method_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_assert_with_predicate_method_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert((obj.one?))
-          ^^^^^^^^^^^^^^^^^^ Prefer using `assert_predicate(obj, :one?)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_predicate(obj, :one?)
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/assert_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/assert_respond_to_test.rb
@@ -85,20 +85,12 @@ class AssertRespondToTest < Minitest::Test
     RUBY
   end
 
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
   def test_registers_offense_when_using_assert_with_respond_to_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert((object.respond_to?(:do_something)))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_respond_to(object, :do_something)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_respond_to((object, :do_something))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_empty_test.rb
+++ b/test/rubocop/cop/minitest/refute_empty_test.rb
@@ -66,20 +66,12 @@ class RefuteEmptyTest < Minitest::Test
     RUBY
   end
 
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
   def test_registers_offense_when_using_refute_with_empty_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute((somestuff.empty?))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_empty(somestuff)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_empty((somestuff))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_includes_test.rb
+++ b/test/rubocop/cop/minitest/refute_includes_test.rb
@@ -66,20 +66,12 @@ class RefuteIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_with_include_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_refute_with_include_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute((collection.include?(object)))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_includes((collection, object))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_match_test.rb
+++ b/test/rubocop/cop/minitest/refute_match_test.rb
@@ -106,7 +106,7 @@ class RefuteMatchTest < Minitest::Test
     end
 
     # Redundant parentheses should be removed in another cop.
-    define_method("test_registers_offense_when_using_refute_with_#{matcher}_in_redundant_parentheses") do
+    define_method("test_does_not_register_offense_when_using_refute_with_#{matcher}_in_redundant_parentheses") do
       assert_no_offenses(<<~RUBY, matcher: matcher)
         class FooTest < Minitest::Test
           def test_do_something

--- a/test/rubocop/cop/minitest/refute_predicate_test.rb
+++ b/test/rubocop/cop/minitest/refute_predicate_test.rb
@@ -64,20 +64,12 @@ class RefutePredicateTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_with_predicate_method_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_refute_with_predicate_method_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute((obj.one?))
-          ^^^^^^^^^^^^^^^^^^ Prefer using `refute_predicate(obj, :one?)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_predicate(obj, :one?)
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/refute_respond_to_test.rb
@@ -85,20 +85,12 @@ class RefuteRespondToTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_with_respond_to_in_redundant_parentheses
-    assert_offense(<<~RUBY)
+  # Redundant parentheses should be removed by `Style/RedundantParentheses` cop.
+  def test_does_not_register_offense_when_using_refute_with_respond_to_in_redundant_parentheses
+    assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute((object.respond_to?(:do_something)))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_respond_to(object, :do_something)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_respond_to((object, :do_something))
         end
       end
     RUBY


### PR DESCRIPTION
rubocop/rubocop#11739 updated `Style/RedundantParentheses` to detect this, so we can now consider it out of scope of these cops, as was done in https://github.com/rubocop/rubocop-minitest/pull/248/files#r1150046949.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
