### PR TITLE
Fix an error for `Minitst/AssertOperator` and `Minitest/RefuteOperator`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  oldest_supported_rubocop:
+    runs-on: ubuntu-latest
+    name: The oldest supported RuboCop version
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use the oldest supported RuboCop
+        run: |
+          sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" -i Gemfile
+          cat << EOF > Gemfile.local
+            gem 'rubocop', '1.39.0' # Specify the oldest supported RuboCop version
+          EOF
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: test
+        run: bundle exec rake

--- a/changelog/fix_error_for_minitest_assert_operator_and_refute_operator.md
+++ b/changelog/fix_error_for_minitest_assert_operator_and_refute_operator.md
@@ -1,0 +1,1 @@
+* [#275](https://github.com/rubocop/rubocop-minitest/pull/275): Make `Minitest/AssertMatch` aware of `assert_operator` when running with Ruby 2.7. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_operator.rb
+++ b/lib/rubocop/cop/minitest/assert_operator.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def build_new_arguments(node)
           lhs, op, rhs = *node.first_argument
-          new_arguments = "#{lhs.source}, :#{op}, #{rhs.source}"
+          new_arguments = +"#{lhs.source}, :#{op}, #{rhs.source}"
 
           if node.arguments.count == 2
             new_arguments << ", #{node.last_argument.source}"

--- a/lib/rubocop/cop/minitest/refute_operator.rb
+++ b/lib/rubocop/cop/minitest/refute_operator.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def build_new_arguments(node)
           lhs, op, rhs = *node.first_argument
-          new_arguments = "#{lhs.source}, :#{op}, #{rhs.source}"
+          new_arguments = +"#{lhs.source}, :#{op}, #{rhs.source}"
 
           if node.arguments.count == 2
             new_arguments << ", #{node.last_argument.source}"


### PR DESCRIPTION
This PR fixes the following error for `Minitst/AssertOperator` and `Minitest/RefuteOperator`
when running with Ruby 2.7:

```console
$ ruby -v
ruby 2.7.8p225 (2023-03-30 revision 1f4d455848) [x86_64-darwin19]

$ bundle exec rake

Finished in 2.522134s, 15.0666 runs/s, 18.6350 assertions/s.

  1) Error: RefuteOperatorTest#test_registers_offense_when_using_refute_with_operator_method_and_message:
FrozenError: can't modify frozen String: "expected, :<, actual"
    /Users/koic/src/github.com/rubocop/rubocop-minitest/lib/rubocop/cop/minitest/refute_operator.rb:46:
    in `build_new_arguments'
    /Users/koic/src/github.com/rubocop/rubocop-minitest/lib/rubocop/cop/minitest/refute_operator.rb:30:
    in `on_send'
```


And it introduces CI for the oldest RuboCop version still supported, implementing a workflow for regression testing that is similar to the one found a https://github.com/rubocop/rubocop-rails/commit/c9acb7a.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x]  Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
