### PR TITLE
[Fix #281] Fix an error when assigning a value to an object attribute

### DIFF
--- a/changelog/fix_an_error_when_using_assigning_a_value_to_an_object_attribute.md
+++ b/changelog/fix_an_error_when_using_assigning_a_value_to_an_object_attribute.md
@@ -1,0 +1,1 @@
+* [#281](https://github.com/rubocop/rubocop-minitest/issues/281): Fix an error when assigning a value to an object attribute. ([@koic][])

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -99,8 +99,9 @@ module RuboCop
         end
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def assertion_method?(node)
-        return assertion_method?(node.expression) if node.assignment?
+        return assertion_method?(node.expression) if node.assignment? && node.respond_to?(:expression)
         return false if !node.send_type? && !node.block_type? && !node.numblock_type?
 
         ASSERTION_PREFIXES.any? do |prefix|
@@ -109,6 +110,7 @@ module RuboCop
           method_name.start_with?(prefix) || node.method?(:flunk)
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def lifecycle_hook_method?(node)
         node.def_type? && LIFECYCLE_HOOK_METHODS.include?(node.method_name)

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -101,6 +101,18 @@ class MultipleAssertionsTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_when_using_assigning_a_value_to_an_object_attribute
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_asserts_once
+          obj.value = 42
+
+          assert_equal(foo, bar)
+        end
+      end
+    RUBY
+  end
+
   def test_generates_a_todo_based_on_the_worst_violation
     inspect_source(<<-RUBY, @cop, 'test/foo_test.rb')
       class FooTest < Minitest::Test


### PR DESCRIPTION
Fixes #281.

This PR fixes an error when assigning a value to an object attribute.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
