### PR TITLE
[Fix #287] don't error on empty blocks when linting `assert_raises`

### DIFF
--- a/changelog/fix_don_t_error_on_empty_blocks_when_linting.md
+++ b/changelog/fix_don_t_error_on_empty_blocks_when_linting.md
@@ -1,0 +1,1 @@
+* [#287](https://github.com/rubocop/rubocop-minitest/issues/287): Don't error on empty blocks when linting `assert_raises`. ([@G-Rath][])

--- a/lib/rubocop/cop/minitest/assert_raises_compound_body.rb
+++ b/lib/rubocop/cop/minitest/assert_raises_compound_body.rb
@@ -37,7 +37,7 @@ module RuboCop
         private
 
         def multi_statement_begin?(node)
-          node.begin_type? && node.children.size > 1
+          node&.begin_type? && node.children.size > 1
         end
       end
     end

--- a/test/rubocop/cop/minitest/assert_raises_compound_body_test.rb
+++ b/test/rubocop/cop/minitest/assert_raises_compound_body_test.rb
@@ -13,6 +13,14 @@ class AssertRaisesCompoundBodyTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_when_empty_bodies
+    assert_no_offenses(<<~RUBY)
+      assert_raises(MyError) do
+        # nothing to see here...
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_single_statement_bodies
     assert_no_offenses(<<~RUBY)
       assert_raises(MyError) do


### PR DESCRIPTION
Fixes #287

This fixes `Minitest/AssertRaisesCompoundBody` erroring on empty blocks

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
