### PR TITLE
[Fix #289] don't count assertions twice when their return value is being assigned

### DIFF
--- a/changelog/fix_don_t_count_assertions_twice_when_their.md
+++ b/changelog/fix_don_t_count_assertions_twice_when_their.md
@@ -1,0 +1,1 @@
+* [#289](https://github.com/rubocop/rubocop-minitest/issues/289): Don't count assertions twice when their return value is being assigned. ([@G-Rath][])


### PR DESCRIPTION
Fixes #289

This fixes `Minitest/MultipleAssertions` counting assertions twice when their return value is being assigned

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
