### PR TITLE
[Fix #289] count asserts within blocks for assignments

### DIFF
--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -67,11 +67,18 @@ module RuboCop
           when :block, :numblock
             assertions_count(node.body)
           when *RuboCop::AST::Node::ASSIGNMENTS
-            # checking assignment bodies is handled by assertion_method?
-            0
+            assertions_count_in_assignment(node)
           else
             node.each_child_node.sum { |child| assertions_count(child) }
           end
+        end
+
+        def assertions_count_in_assignment(node)
+          # checking the direct expression is handled by assertion_method?
+          return 0 unless node.expression.block_type? || node.expression.numblock_type?
+
+          # this will only trigger the branches for :block and :numblock type nodes
+          assertions_count_based_on_type(node.expression)
         end
 
         def assertions_count_in_branches(branches)


### PR DESCRIPTION
Follow up to #290 / #289 - I realised when re-reviewing my change that `assertion_method?` only checks the immediate expression of assignments, which makes sense for what it's meant to be doing - so we need to still handle checking the bodies of blocks for assignments.

I've not added a changelog for this since the original PR has not been released so I figured it would still be considered a single "fix", but let me know if you'd still like a second changelog entry anyway.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
