### PR TITLE
[Fix #292] ensure all kinds of assignments are correctly handled when counting assertions

### DIFF
--- a/changelog/fix_ensure_all_kinds_of_assignments_are.md
+++ b/changelog/fix_ensure_all_kinds_of_assignments_are.md
@@ -1,0 +1,1 @@
+* [#292](https://github.com/rubocop/rubocop-minitest/issues/292): Ensure all kinds of assignments are correctly handled when counting assertions. ([@G-Rath][])


### PR DESCRIPTION
Fixes #292
Fixes #295

This ensures that `Minitest/MultipleAssertions` properly counts assertions when dealing with assignments - I expect (and hope) this is pretty rare in real-world code, but it is technically correct for the cop to be doing and the actual support isn't that complex.

I've only added a single test to ensure all the types of assignment work, and then a test using the standard assignment operator for each different kind of complex node (block, if, rescue, etc) since they all work the same except for mass assignment and it would be very tedious to write all those tests; they could be done through loops but I'm not sure its worth it vs the complexity.

Speaking of mass assignment, that is the fly in the ointment - I've added support for single method and array, and then had it just bail otherwise because I expect this to be the rarest of rare cases and worst case a follow-up PR can be done expanding its support; I know already that this doesn't cover assigning hashes (i.e. `x, y => { "value" => assert("why...?") }`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
