### PR TITLE
Raise an exception if tests or changelog generation fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
           bundler-cache: true
       - name: test
         run: bundle exec rake test
+        env:
+          ERROR_ON_TEST_FAILURE: "false"
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 
@@ -84,3 +86,5 @@ jobs:
           bundler-cache: true
       - name: test
         run: bundle exec rake test
+        env:
+          ERROR_ON_TEST_FAILURE: "false"

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ require_relative 'lib/rubocop/cop/generator'
 
 desc 'Run tests'
 task :test do
-  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}")
+  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}", exception: true)
 end
 
 desc 'Run RuboCop over itself'

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,9 @@ require_relative 'lib/rubocop/cop/generator'
 
 desc 'Run tests'
 task :test do
-  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}", exception: true)
+  error_on_failure = ENV.fetch('ERROR_ON_TEST_FAILURE', 'true') != 'false'
+
+  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}", exception: error_on_failure)
 end
 
 desc 'Run RuboCop over itself'

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -9,7 +9,7 @@ namespace :changelog do
       ref_type = :pull if args[:id]
       path = Changelog::Entry.new(type: type, ref_id: args[:id], ref_type: ref_type).write
       cmd = "git add #{path}"
-      system cmd
+      system cmd, exception: true
       puts "Entry '#{path}' created and added to git index"
     end
   end
@@ -21,7 +21,7 @@ namespace :changelog do
     Changelog.new.merge!.and_delete!
     cmd = "git commit -a -m 'Update Changelog'"
     puts cmd
-    system cmd
+    system cmd, exception: true
   end
 
   task :check_clean do


### PR DESCRIPTION
I realised while working on my recent PRs that CI wasn't actually failing when `bundle exec rake [test]` reported errors - turns out that tests are being invoked by `system` which by default does not do any error handling; instead it sets `$?` to the exit code which can then be checked.

Ruby 2.6 added an `exception` option which when `true` causes `system` to raise an exception if the command exits with a non-zero code, making this very easy to address.

I've checked the codebase and confirmed these are the only uses of `system`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
