### PR TITLE
Don't use `test-queue` to run tests on JRuby because it doesn't support `fork`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,6 @@ jobs:
           bundler-cache: true
       - name: test
         run: bundle exec rake test
-        env:
-          ERROR_ON_TEST_FAILURE: "false"
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,11 +19,20 @@ require 'rubocop/rake_task'
 require 'rake/testtask'
 require_relative 'lib/rubocop/cop/generator'
 
-desc 'Run tests'
-task :test do
-  error_on_failure = ENV.fetch('ERROR_ON_TEST_FAILURE', 'true') != 'false'
+# JRuby and Windows don't support fork, so we can't use minitest-queue.
+if RUBY_ENGINE == 'jruby' || RuboCop::Platform.windows?
+  Rake::TestTask.new do |t|
+    t.libs << 'test'
+    t.libs << 'lib'
+    t.test_files = FileList['test/**/*_test.rb']
+  end
+else
+  desc 'Run tests'
+  task :test do
+    error_on_failure = ENV.fetch('ERROR_ON_TEST_FAILURE', 'true') != 'false'
 
-  system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}", exception: error_on_failure)
+    system("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}", exception: error_on_failure)
+  end
 end
 
 desc 'Run RuboCop over itself'


### PR DESCRIPTION
Follow up to #294

Currently this is aimed at being the most straightforward if probably slightly inelegant way to get tests running on JRuby - I assume there is probably a slightly cleaner way of invoking tests but I don't yet know what it is and `Rake::TestTask` was more than a few lines of code 😅

I think it would be worth considering having `test-queue` "support" JRuby by not using `fork` if that platform is detected or if you set `TEST_QUEUE_WORKERS` to 1 (or maybe 0?) as a way of making it easier to have a normalized way of invoking tests across different platforms like this; but it would also be equally valid I think for `test-queue` to say that's out of scope for the gem🤷 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
