### PR TITLE
Skip pattern matching tests when running on older versions of Rubocop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,5 +84,3 @@ jobs:
           bundler-cache: true
       - name: test
         run: bundle exec rake test
-        env:
-          ERROR_ON_TEST_FAILURE: "false"

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -426,6 +426,8 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_registers_offense_when_multiple_expectations_inside_pattern_matching
+    skip_unless_rubocop_supports_pattern_matching!
+
     assert_offense(<<~RUBY)
       class FooTest < ActiveSupport::TestCase
         test 'something' do
@@ -447,6 +449,8 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_registers_offense_when_multiple_expectations_inside_assigned_pattern_matching
+    skip_unless_rubocop_supports_pattern_matching!
+
     assert_offense(<<~RUBY)
       class FooTest < ActiveSupport::TestCase
         test 'something' do
@@ -468,6 +472,8 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_does_not_register_offense_when_single_assertion_inside_pattern_matching
+    skip_unless_rubocop_supports_pattern_matching!
+
     assert_no_offenses(<<~RUBY)
       class FooTest < ActiveSupport::TestCase
         test 'something' do
@@ -687,5 +693,9 @@ class MultipleAssertionsTest < Minitest::Test
   def configure_max_assertions(max)
     cop_config = RuboCop::Config.new('Minitest/MultipleAssertions' => { 'Max' => max })
     @cop = RuboCop::Cop::Minitest::MultipleAssertions.new(cop_config)
+  end
+
+  def skip_unless_rubocop_supports_pattern_matching!
+    skip if RuboCop::TargetRuby::DEFAULT_VERSION < 2.7
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-minitest/pull/294

I don't know why but these two pattern matching tests throw parsing errors on Rubocop <1.52 - I can't find anything in the changelog to indicate what actually changed in v1.52, nor can I reproduce this locally outside of the test suite; I've also checked the versions of other gems (notably `rubocop-ast`) and confirmed the issues seems to be within `rubocop` itself.

Since there are only two tests impacted I think this is fine - even if no one spends the time figuring out the specifics to improve this, eventually it'll go away when support for Ruby 2.7 and older versions of Rubocop are dropped 🤷 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
