### PR TITLE
`AssertKindOf`: also replace `is_a?` as well

### DIFF
--- a/changelog/change_AssertKindOf_is_a.md
+++ b/changelog/change_AssertKindOf_is_a.md
@@ -1,0 +1,1 @@
+* [#298](https://github.com/rubocop/rubocop-minitest/pull/298): Extend `Minitest/AssertKindOf` to also correct `assert(object.is_a?(Class))`. ([@amomchilov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -46,6 +46,7 @@ Minitest/AssertKindOf:
   StyleGuide: 'https://github.com/rubocop/minitest-style-guide#assert-kind-of'
   Enabled: 'pending'
   VersionAdded: '0.10'
+  VersionChanged: '<<next>>'
 
 Minitest/AssertMatch:
   Description: 'This cop enforces the test to use `assert_match` instead of using `assert(matcher.match(object))`.'
@@ -252,6 +253,7 @@ Minitest/RefuteKindOf:
   StyleGuide: 'https://github.com/rubocop/minitest-style-guide#refute-kind-of'
   Enabled: 'pending'
   VersionAdded: '0.10'
+  VersionChanged: '<<next>>'
 
 Minitest/RefuteMatch:
   Description: 'This cop enforces the test to use `refute_match` instead of using `refute(matcher.match(object))`.'

--- a/lib/rubocop/cop/minitest/assert_kind_of.rb
+++ b/lib/rubocop/cop/minitest/assert_kind_of.rb
@@ -11,6 +11,11 @@ module RuboCop
       #   assert(object.kind_of?(Class))
       #   assert(object.kind_of?(Class), 'message')
       #
+      #   # bad
+      #   # `is_a?` is an alias for `kind_of?`
+      #   assert(object.is_a?(Class))
+      #   assert(object.is_a?(Class), 'message')
+      #
       #   # good
       #   assert_kind_of(Class, object)
       #   assert_kind_of(Class, object, 'message')
@@ -18,7 +23,7 @@ module RuboCop
       class AssertKindOf < Base
         extend MinitestCopRule
 
-        define_rule :assert, target_method: :kind_of?, inverse: true
+        define_rule :assert, target_method: %i[kind_of? is_a?], preferred_method: :assert_kind_of, inverse: true
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_kind_of.rb
+++ b/lib/rubocop/cop/minitest/refute_kind_of.rb
@@ -11,6 +11,11 @@ module RuboCop
       #   refute(object.kind_of?(Class))
       #   refute(object.kind_of?(Class), 'message')
       #
+      #   # bad
+      #   # `is_a?` is an alias for `kind_of?`
+      #   refute(object.is_of?(Class))
+      #   refute(object.is_of?(Class), 'message')
+      #
       #   # good
       #   refute_kind_of(Class, object)
       #   refute_kind_of(Class, object, 'message')
@@ -18,7 +23,7 @@ module RuboCop
       class RefuteKindOf < Base
         extend MinitestCopRule
 
-        define_rule :refute, target_method: :kind_of?, inverse: true
+        define_rule :refute, target_method: %i[kind_of? is_a?], preferred_method: :refute_kind_of, inverse: true
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_kind_of_test.rb
+++ b/test/rubocop/cop/minitest/assert_kind_of_test.rb
@@ -22,12 +22,50 @@ class AssertKindOfTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_is_a
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(object.is_a?(SomeClass))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_kind_of(SomeClass, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_kind_of(SomeClass, object)
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_assert_with_kind_of_and_message
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert(object.kind_of?(SomeClass), 'message')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_kind_of(SomeClass, object, 'message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_kind_of(SomeClass, object, 'message')
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_is_a_and_message
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(object.is_a?(SomeClass), 'message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_kind_of(SomeClass, object, 'message')`.
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_kind_of_test.rb
+++ b/test/rubocop/cop/minitest/refute_kind_of_test.rb
@@ -22,12 +22,50 @@ class RefuteKindOfTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_with_kind_of_and_message
+  def test_registers_offense_when_using_refute_with_is_a
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(object.is_a?(SomeClass))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_kind_of(SomeClass, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_kind_of(SomeClass, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_is_a_and_message
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute(object.kind_of?(SomeClass), 'message')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_kind_of(SomeClass, object, 'message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_kind_of(SomeClass, object, 'message')
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_kind_of_and_message
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(object.is_a?(SomeClass), 'message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_kind_of(SomeClass, object, 'message')`.
         end
       end
     RUBY


### PR DESCRIPTION
The [`Minitest/AssertKindOf`](https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestassertkindof) would replace this code:

```ruby
assert(object.kind_of?(Class))
```

... but not:

```ruby
assert(object.is_a?(Class))
```

...even though they are practically the same, since [`#is_a?`](https://ruby-doc.org/3.2.2/Object.html#method-i-is_a-3F) is an alias for [`#kind_of?`](https://ruby-doc.org/3.2.2/Object.html#method-i-kind_of-3F) (not to be confused with [`#instance_of?`](https://ruby-doc.org/3.2.2/Object.html#method-i-instance_of-3F)).

This PR simply extends `Minitest/AssertKindOf` to correct both.

I opted to modify the existing cop, rather than introducing a new cop like `Minitest/AssertIsA`, because it seems really unlikely to me that somebody would like to correct one, but not the other. Perhaps that's just a lack of imagination, let me know if there are any objections.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
