### PR TITLE
Fix an error for `Style/UselessAssertion` when passing a single argument to methods to accept two arguments

### DIFF
--- a/changelog/fix_an_error_for_style_useless_assertion.md
+++ b/changelog/fix_an_error_for_style_useless_assertion.md
@@ -1,0 +1,1 @@
+* [#299](https://github.com/rubocop/rubocop-minitest/pull/299): Fix an error for `Style/UselessAssertion` when passing a single argument to methods to accept two arguments. ([@earlopain][])

--- a/lib/rubocop/cop/minitest/useless_assertion.rb
+++ b/lib/rubocop/cop/minitest/useless_assertion.rb
@@ -48,7 +48,7 @@ module RuboCop
           when *SINGLE_ASSERTION_ARGUMENT_METHODS
             actual.nil? && expected&.literal? && !expected.xstr_type?
           when *TWO_ASSERTION_ARGUMENTS_METHODS
-            return false unless expected || actual
+            return false unless expected && actual
             return false if expected.source != actual.source
 
             (expected.variable? && actual.variable?) ||

--- a/test/rubocop/cop/minitest/useless_assertion_test.rb
+++ b/test/rubocop/cop/minitest/useless_assertion_test.rb
@@ -93,6 +93,12 @@ class UselessAssertionTest < Minitest::Test
         #{matcher} x.foo, x.foo
       RUBY
     end
+
+    define_method("test_#{matcher}_no_offense_when_only_single_argument_is_given") do
+      assert_no_offenses(<<~RUBY)
+        #{matcher} foo
+      RUBY
+    end
   end
 
   %i[assert_includes refute_includes].each do |matcher|


### PR DESCRIPTION
This fixes an error for the followng code snippet:

```rb
assert_equal(1)
```

The code is broken and doesn't work but if using rubocop in lsp mode something that a user can type momentarily.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
