### PR TITLE
Fix an error for `Minitest/AssertEmptyLiteral` when only passing an empty literal

### DIFF
--- a/changelog/fix_an_error_for_assert_empty_literal.md
+++ b/changelog/fix_an_error_for_assert_empty_literal.md
@@ -1,0 +1,1 @@
+* [#300](https://github.com/rubocop/rubocop-minitest/pull/300): Fix an error for `Minitest/AssertEmptyLiteral` when only passing an empty literal. ([@earlopain][])

--- a/lib/rubocop/cop/minitest/assert_empty_literal.rb
+++ b/lib/rubocop/cop/minitest/assert_empty_literal.rb
@@ -22,7 +22,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         def_node_matcher :assert_equal_with_empty_literal, <<~PATTERN
-          (send nil? :assert_equal ${hash array} $...)
+          (send nil? :assert_equal ${hash array} $_+)
         PATTERN
 
         def on_send(node)

--- a/test/rubocop/cop/minitest/assert_empty_literal_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_literal_test.rb
@@ -60,4 +60,14 @@ class AssertEmptyLiteralTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_only_passing_empty_hash_to_assert_equal
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal({})
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Another error that is more likely to occur while running RuboCop in LSP mode.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
