### PR TITLE
Require RuboCop 1.61 to use `AutoCorrect: Contextual`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.39.0' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.61.0' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/change_require_rubocop_1_61.md
+++ b/changelog/change_require_rubocop_1_61.md
@@ -1,0 +1,1 @@
+* [#303](https://github.com/rubocop/rubocop-minitest/pull/303): Require RuboCop 1.61 to use `AutoCorrect: Contextual`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -149,6 +149,7 @@ Minitest/EmptyLineBeforeAssertionMethods:
 Minitest/Focus:
   Description: 'Checks for focused tests.'
   Enabled: pending
+  AutoCorrect: contextual
   VersionAdded: '<<next>>'
 
 Minitest/GlobalExpectations:

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.39', '< 2.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.61', '< 2.0'
   spec.add_runtime_dependency 'rubocop-ast', '>= 1.30.0', '< 2.0'
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-minitest/pull/302#issuecomment-1945308338.

This PR updates the dependency version to RuboCop 1.61, which supports `AutoCorrect: contextual`, and updates `Minitest/Focus`'s config.
https://github.com/rubocop/rubocop/releases/tag/v1.61.0

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
