### PR TITLE
Support Prism as a Ruby parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,22 @@ jobs:
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 
+  prism:
+    runs-on: ubuntu-latest
+    name: Prism
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Specify the minimum Ruby version 2.7 required for Prism to run.
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: test
+        env:
+          PARSER_ENGINE: parser_prism
+        run: bundle exec rake prism_test
+
   documentation_checks:
     runs-on: ubuntu-latest
     name: Check documentation syntax

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 gem 'bump', require: false
 gem 'minitest', '~> 5.11'
 gem 'minitest-proveit'
+gem 'prism'
 gem 'rake'
 gem 'rubocop', github: 'rubocop/rubocop'
 gem 'rubocop-performance', '~> 1.18.0'

--- a/Rakefile
+++ b/Rakefile
@@ -33,10 +33,15 @@ else
   end
 end
 
+desc 'Run tests with Prism'
+task :prism_test do
+  sh('PARSER_ENGINE=parser_prism bundle exec rake test')
+end
+
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation)
 
-task default: %i[documentation_syntax_check test internal_investigation]
+task default: %i[documentation_syntax_check test prism_test internal_investigation]
 
 desc 'Generate a new cop template'
 task :new_cop, [:cop] do |_task, args|

--- a/changelog/change_support_prism.md
+++ b/changelog/change_support_prism.md
@@ -1,0 +1,1 @@
+* [#304](https://github.com/rubocop/rubocop-minitest/pull/304): Require RuboCop AST >= 1.31.1 to support Prism as a Ruby Parser. ([@koic][])

--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -186,7 +186,7 @@ module RuboCop
           file = file.path
         end
 
-        processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file)
+        processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file, parser_engine: parser_engine)
 
         # Follow up https://github.com/rubocop/rubocop/pull/10987.
         # When support for RuboCop 1.37.1 ends, this condition can be removed.
@@ -216,7 +216,12 @@ module RuboCop
       end
 
       def ruby_version
-        RuboCop::TargetRuby::DEFAULT_VERSION
+        #  Prism supports parsing Ruby 3.3+.
+        ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : RuboCop::TargetRuby::DEFAULT_VERSION
+      end
+
+      def parser_engine
+        ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rubocop', '>= 1.61', '< 2.0'
-  spec.add_runtime_dependency 'rubocop-ast', '>= 1.30.0', '< 2.0'
+  spec.add_runtime_dependency 'rubocop-ast', '>= 1.31.1', '< 2.0'
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-ast/pull/277

There are no changes to the implementation, but the required dependency version of RuboCop AST will be updated. It would be more rational than adding new dependency on `gem 'rubocop-ast', '>= 1.31.1'` in the Gemfile just to bump up the minor version.

RuboCop Minitest now ensures that `RuboCop::AST::ProcessedSource` used in tests is aware of `parser_engine` parameter.

Tests for RuboCop AST with Prism as the backend can be run as follows:

```console
bundle exec rake prism_test
```

The above is the shortcut alias for:

```console
PARSER_ENGINE=parser_prism bundle exec rake test
```

RuboCop works on Ruby versions 2.7+, but since Prism only targets parsing for Ruby 3.3+, `internal_investigation` Rake task will not be executed. This task is only run with the Parser gem, which can parse Ruby versions 2.0+.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
