### PR TITLE
Remove a workaround for older RuboCop versions

### DIFF
--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -187,14 +187,8 @@ module RuboCop
         end
 
         processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file, parser_engine: parser_engine)
-
-        # Follow up https://github.com/rubocop/rubocop/pull/10987.
-        # When support for RuboCop 1.37.1 ends, this condition can be removed.
-        if processed_source.respond_to?(:config) && processed_source.respond_to?(:registry)
-          processed_source.config = configuration
-          processed_source.registry = registry
-        end
-
+        processed_source.config = configuration
+        processed_source.registry = registry
         processed_source
       end
 


### PR DESCRIPTION
The minimal supported version is currently 1.61. This condition is not needed anymore

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
