### PR TITLE
Make `AssertOffense` support `assert_no_corrections`

### DIFF
--- a/changelog/new_support_no_corrections.md
+++ b/changelog/new_support_no_corrections.md
@@ -1,0 +1,1 @@
+* [#307](https://github.com/rubocop/rubocop-minitest/pull/307): Make `AssertOffense` support `assert_no_corrections`. ([@koic][])


### PR DESCRIPTION
Despite being mentioned in the `AssertOffense` documentation, `assert_no_corrections` was not supported: https://github.com/rubocop/rubocop-minitest/blob/v0.35.0/lib/rubocop/minitest/assert_offense.rb#L58-L72

This PR makes `assert_no_corrections` supported in accordance with the documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
