### PR TITLE
Make `UselssAssertion` autocorrect `contextual`

### DIFF
--- a/changelog/change_make_useless_assertion_as_contextual.md
+++ b/changelog/change_make_useless_assertion_as_contextual.md
@@ -1,0 +1,1 @@
+* [#308](https://github.com/rubocop/rubocop-minitest/pull/308): Make `UselssAssertion` autocorrect `contextual`. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -349,3 +349,4 @@ Minitest/UselessAssertion:
   Description: 'Detects useless assertions (assertions that either always pass or always fail).'
   Enabled: pending
   VersionAdded: '0.26'
+  AutoCorrect: contextual


### PR DESCRIPTION
This is an annoying autocorrect to happen while typing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
