### PR TITLE
Fix readme CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RuboCop Minitest
 
 [![Gem Version](https://badge.fury.io/rb/rubocop-minitest.svg)](https://badge.fury.io/rb/rubocop-minitest)
-[![CircleCI](https://circleci.com/gh/rubocop/rubocop-minitest.svg?style=svg)](https://circleci.com/gh/rubocop/rubocop-minitest)
+[![CI](https://github.com/rubocop/rubocop-minitest/actions/workflows/test.yml/badge.svg)](https://github.com/rubocop/rubocop-minitest/actions/workflows/test.yml)
 
 A [RuboCop](https://github.com/rubocop/rubocop) extension focused on enforcing [Minitest](https://github.com/minitest/minitest) best practices and coding conventions.
 The library is based on the guidelines outlined in the community [Minitest Style Guide](https://minitest.rubystyle.guide).


### PR DESCRIPTION
There's no CircleCI here, it's all GitHub actions: #277

![image](https://github.com/rubocop/rubocop-minitest/assets/14981592/95ab2172-c9f5-45d2-b75b-db09fd58c285)
