### PR TITLE
Suppress deprecation warning for `Minitst/MultipleAssertions`

### DIFF
--- a/changelog/fix_suppress_deprecation_warning_for_minitest_multiple_assertions.md
+++ b/changelog/fix_suppress_deprecation_warning_for_minitest_multiple_assertions.md
@@ -1,0 +1,1 @@
+* [#311](https://github.com/rubocop/rubocop-minitest/pull/311): Suppress deprecation warning for `Minitst/MultipleAssertions`. ([@koic][])

--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -28,10 +28,11 @@ module RuboCop
       #   end
       #
       class MultipleAssertions < Base
-        include ConfigurableMax
         include MinitestExplorationHelpers
 
         MSG = 'Test case has too many assertions [%<total>d/%<max>d].'
+
+        exclude_limit 'Max'
 
         def on_class(class_node)
           return unless test_class?(class_node)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/13032 and https://github.com/rubocop/rubocop/pull/9471.

This PR suppresses deprecation warning for `Minitst/MultipleAssertions`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
