### PR TITLE
Tests using AssertOffense should Fail with a usable message if the relevant cop is not defined

### DIFF
--- a/changelog/change_assert_offense_setup_fails_with_useful_message.md
+++ b/changelog/change_assert_offense_setup_fails_with_useful_message.md
@@ -1,0 +1,1 @@
+* [#314](https://github.com/rubocop/rubocop-minitest/pull/314): **(Breaking)** Raise a useful error when using a Cop in `AssertOffense` if the Cop's class is not defined. ([@brandoncc][])

--- a/test/rubocop/cop/minitest/assert_offense_test.rb
+++ b/test/rubocop/cop/minitest/assert_offense_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../../test_helper'
+
+class AssertOffenseTest
+  class CopNotDefinedTest < Minitest::Test
+    def test_correct_failure_is_raised_when_cop_is_not_defined
+      error = assert_raises RuntimeError do
+        assert_offense(<<~RUBY)
+          class FooTest < Minitest::Test
+            def test_do_something
+              assert_equal(nil, somestuff)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff)`.
+            end
+          end
+        RUBY
+      end
+
+      assert_includes error.message, 'Cop not defined'
+    end
+  end
+end

--- a/test/rubocop/cop/minitest/test_file_name_test.rb
+++ b/test/rubocop/cop/minitest/test_file_name_test.rb
@@ -4,7 +4,7 @@ require_relative '../../../test_helper'
 
 class TestFileNameTest < Minitest::Test
   def test_registers_offense_for_invalid_path
-    offenses = inspect_source(<<~RUBY, @cop, 'lib/foo.rb')
+    offenses = inspect_source(<<~RUBY, cop, 'lib/foo.rb')
       class FooTest < Minitest::Test
       end
     RUBY
@@ -15,7 +15,7 @@ class TestFileNameTest < Minitest::Test
   end
 
   def test_registers_offense_for_namespaced_invalid_path
-    offenses = inspect_source(<<~RUBY, @cop, 'lib/foo/bar.rb')
+    offenses = inspect_source(<<~RUBY, cop, 'lib/foo/bar.rb')
       module Foo
         class BarTest < Minitest::Test
         end


### PR DESCRIPTION
Including the `AssertOffense` module currently fails with a cryptic message if the cop can't be found. This PR introduces an explicit failure with a useful message, replacing the `NoMethodError` that is currently raised in this situation.

**Before**

```
Error:
RuboCop::Cop::MyCops::MyNewCopTest#test_works:
NoMethodError: undefined method `[]=' for nil
    /Users/brandoncc/.gem/ruby/3.3.1/gems/rubocop-minitest-0.35.1/lib/rubocop/minitest/assert_offense.rb:109:in `assert_offense'
    test/rubocop/cop/my_cops/my_new_cop_test.rb:12:in `block in <class:MyNewCopTest>'
```

**After**

```
Error:
RuboCop::Cop::MyCops::MyNewCopTest#test_works:
RuntimeError: Cop not defined: RuboCop::Cop::MyCops::MyNewCop
    /Users/brandoncc/dev/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:81:in `cop'
    /Users/brandoncc/dev/rubocop-minitest/lib/rubocop/minitest/assert_offense.rb:111:in `assert_offense'
    test/rubocop/cop/my_cops/my_new_cop_test.rb:12:in `block in <class:MyNewCopTest>'
```

My first implementation [simply changed `AssertOffense#setup`](https://github.com/rubocop/rubocop-minitest/commit/8ab6c91e19a098eb4021f9afd0bbd35f2ebcaeb3) to fail if the cop wasn't found, but that broke four tests in the test suite. Given that the advice given is to require `support.rb`, which [includes `AssertOffense` on every instance of `Minitest::Test`](https://github.com/rubocop/rubocop-minitest/blob/4d08365be08d06b02bb2c11415a4e8060331a0bb/lib/rubocop/minitest/support.rb#L10), I realized that implementation was likely to break many gem-consumer repositories in this same way.

The second implementation refactors the initialization of a Cop to be lazy, so that the error is only raised when the cop is attempted to be accessed. This has the downside of `@cop` being `nil` until `#cop` is called, but these failures will only happen in tests where `@cop` is accessed directly. I believe these failures, if experienced by consumers of the gem, will be easier to resolve than the errors likely to have been introduced by my first implementation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
