### PR TITLE
Fix an error for `Minitest/SkipEnsure` when only `ensure` has a body

### DIFF
--- a/changelog/fix_error_skip_ensure.md
+++ b/changelog/fix_error_skip_ensure.md
@@ -1,0 +1,1 @@
+* [#314](https://github.com/rubocop/rubocop-minitest/pull/314): Fix an error for `Minitest/SkipEnsure` when only `ensure` has a body. ([@earlopain][])

--- a/lib/rubocop/cop/minitest/skip_ensure.rb
+++ b/lib/rubocop/cop/minitest/skip_ensure.rb
@@ -75,7 +75,9 @@ module RuboCop
         private
 
         def find_skip(node)
-          node.node_parts.first.descendants.detect { |n| n.send_type? && n.receiver.nil? && n.method?(:skip) }
+          return unless (body = node.node_parts.first)
+
+          body.descendants.detect { |n| n.send_type? && n.receiver.nil? && n.method?(:skip) }
         end
 
         def use_skip_in_rescue?(skip_method)

--- a/test/rubocop/cop/minitest/skip_ensure_test.rb
+++ b/test/rubocop/cop/minitest/skip_ensure_test.rb
@@ -119,4 +119,13 @@ class SkipEnsureTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_registers_no_offese_when_ensure_only
+    assert_no_offenses(<<~RUBY)
+      def test_ensure_only
+      ensure
+        do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Found at https://github.com/Shopify/shopify_app/blob/1dda5cb5642e34338961cc65d8069455e568e162/test/shopify_app/controller_concerns/token_exchange_test.rb#L30-L35

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
