### PR TITLE
Fix an error for `Minitest/MultipleAssertions` when using for-style loops

### DIFF
--- a/changelog/fix_error_multiple_assertions.md
+++ b/changelog/fix_error_multiple_assertions.md
@@ -1,0 +1,1 @@
+* [#317](https://github.com/rubocop/rubocop-minitest/pull/317): Fix an error for `Minitest/MultipleAssertions` when using for-style loops. ([@earlopain][])

--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -75,7 +75,11 @@ module RuboCop
         end
 
         def assertions_count_in_assignment(node)
-          return assertions_count_based_on_type(node.expression) unless node.masgn_type?
+          unless node.masgn_type?
+            return 0 unless node.expression # for-style loop
+
+            return assertions_count_based_on_type(node.expression)
+          end
 
           rhs = node.children.last
 

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -616,6 +616,20 @@ class MultipleAssertionsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_for_style_loop
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_asserts_twice
+        ^^^^^^^^^^^^^^^^^^^^^^ Test case has too many assertions [2/1].
+          assert_equal(foo, bar)
+          for baz in [1, 2]
+            assert_equal(baz, 1)
+          end
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_complex_multiple_assignment_structure_and_multiple_assertions
     skip 'FIXME: The shared `@cop` instance variable causes flaky tests due to state changes.'
 


### PR DESCRIPTION
They produce an assign node, but the value is part of the parent for node.

I noticed there are some flaky tests in that file being skipped. I enabled them locally, and they pass with this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
