### PR TITLE
Add `{Assert,Refute}Match` `OnlyRegexpLiteral` config

### DIFF
--- a/changelog/new_add_assert_refute_match.md
+++ b/changelog/new_add_assert_refute_match.md
@@ -1,0 +1,1 @@
+* [#323](https://github.com/rubocop/rubocop-minitest/pull/323): Add `{Assert,Refute}Match` `OnlyRegexpLiteral` config. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -53,6 +53,7 @@ Minitest/AssertMatch:
   StyleGuide: 'https://minitest.rubystyle.guide#assert-match'
   Enabled: true
   VersionAdded: '0.6'
+  OnlyRegexpLiteral: false
 
 Minitest/AssertNil:
   Description: 'This cop enforces the test to use `assert_nil` instead of using `assert_equal(nil, something)` or `assert(something.nil?)`.'
@@ -266,6 +267,7 @@ Minitest/RefuteMatch:
   StyleGuide: 'https://minitest.rubystyle.guide#refute-match'
   Enabled: true
   VersionAdded: '0.6'
+  OnlyRegexpLiteral: false
 
 Minitest/RefuteNil:
   Description: 'This cop enforces the test to use `refute_nil` instead of using `refute_equal(nil, something)` or `refute(something.nil?)`.'

--- a/lib/rubocop/cop/minitest/assert_match.rb
+++ b/lib/rubocop/cop/minitest/assert_match.rb
@@ -20,48 +20,31 @@ module RuboCop
       #
       class AssertMatch < Base
         include ArgumentRangeHelper
+        include AssertRefuteMatchHelper
         extend AutoCorrector
 
         MSG = 'Prefer using `assert_match(%<preferred>s)`.'
         RESTRICT_ON_SEND = %i[assert assert_operator].freeze
 
-        def_node_matcher :assert_match, <<~PATTERN
+        def_node_matcher :match_assertion, <<~PATTERN
           {
             (send nil? :assert (send $_ {:match :match? :=~} $_) $...)
             (send nil? :assert_operator $_ (sym :=~) $_ $...)
           }
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
         def on_send(node)
-          assert_match(node) do |expected, actual, rest_args|
-            basic_arguments = order_expected_and_actual(expected, actual)
-            preferred = (message_arg = rest_args.first) ? "#{basic_arguments}, #{message_arg.source}" : basic_arguments
-            message = format(MSG, preferred: preferred)
-
-            add_offense(node, message: message) do |corrector|
-              corrector.replace(node.loc.selector, 'assert_match')
-
-              range = if node.method?(:assert)
-                        node.first_argument
-                      else
-                        node.first_argument.source_range.begin.join(node.arguments[2].source_range.end)
-                      end
-
-              corrector.replace(range, basic_arguments)
-            end
-          end
+          check_match_assertion(node)
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 
-        def order_expected_and_actual(expected, actual)
-          if actual.regexp_type?
-            [actual, expected]
-          else
-            [expected, actual]
-          end.map(&:source).join(', ')
+        def basic_preferred_assertion_method_name
+          :assert
+        end
+
+        def preferred_assertion_method_name
+          :assert_match
         end
       end
     end

--- a/lib/rubocop/cop/minitest/assert_match.rb
+++ b/lib/rubocop/cop/minitest/assert_match.rb
@@ -18,6 +18,25 @@ module RuboCop
       #   assert_match(regex, string)
       #   assert_match(matcher, string, 'message')
       #
+      # @example OnlyRegexpLiteral: false (default)
+      #   # bad
+      #   assert /.../.match?(object)
+      #   assert object.match?(/.../)
+      #   assert matcher.match?(object)
+      #
+      #   # good
+      #   assert_match(/.../, object)
+      #   assert_match(matcher, object)
+      #
+      # @example OnlyRegexpLiteral: true
+      #   # bad
+      #   assert /.../.match?(object)
+      #   assert object.match?(/.../)
+      #
+      #   # good
+      #   assert_match(/.../, object)
+      #   assert_match(matcher, object)
+      #
       class AssertMatch < Base
         include ArgumentRangeHelper
         include AssertRefuteMatchHelper

--- a/lib/rubocop/cop/minitest/refute_match.rb
+++ b/lib/rubocop/cop/minitest/refute_match.rb
@@ -19,6 +19,24 @@ module RuboCop
       #   refute_match(matcher, string)
       #   refute_match(matcher, string, 'message')
       #
+      # @example OnlyRegexpLiteral: false (default)
+      #   # bad
+      #   refute /.../.match?(object)
+      #   refute object.match?(/.../)
+      #   refute matcher.match?(object)
+      #
+      #   # good
+      #   refute_match(/.../, object)
+      #   refute_match(matcher, object)
+      #
+      # @example OnlyRegexpLiteral: true
+      #   # bad
+      #   refute /.../.match?(object)
+      #   refute object.match?(/.../)
+      #
+      #   # good
+      #   refute_match(/.../, object)
+      #   refute_match(matcher, object)
       class RefuteMatch < Base
         include ArgumentRangeHelper
         include AssertRefuteMatchHelper

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/argument_range_helper'
+require_relative 'mixin/assert_refute_match_helper'
 require_relative 'mixin/in_delta_mixin'
 require_relative 'mixin/instance_of_assertion_handleable'
 require_relative 'mixin/minitest_cop_rule'

--- a/lib/rubocop/cop/mixin/assert_refute_match_helper.rb
+++ b/lib/rubocop/cop/mixin/assert_refute_match_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common implementation for `AssertMatch` and `RefuteMatch` cops.
+    module AssertRefuteMatchHelper
+      private
+
+      def check_match_assertion(node)
+        match_assertion(node) do |expected, actual, rest_args|
+          basic_arguments = order_expected_and_actual(expected, actual)
+
+          add_offense(node, message: format_message(basic_arguments, rest_args)) do |corrector|
+            corrector.replace(node.loc.selector, preferred_assertion_method_name)
+            corrector.replace(assertion_arguments_range(node), basic_arguments)
+          end
+        end
+      end
+
+      def format_message(basic_arguments, rest_args)
+        preferred = (message_arg = rest_args.first) ? "#{basic_arguments}, #{message_arg.source}" : basic_arguments
+
+        format(self.class::MSG, preferred: preferred)
+      end
+
+      def assertion_arguments_range(node)
+        if node.method?(basic_preferred_assertion_method_name)
+          node.first_argument
+        else
+          node.first_argument.source_range.begin.join(node.arguments[2].source_range.end)
+        end
+      end
+
+      def order_expected_and_actual(expected, actual)
+        if actual.regexp_type?
+          [actual, expected]
+        else
+          [expected, actual]
+        end.map(&:source).join(', ')
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/minitest/assert_match_test.rb
+++ b/test/rubocop/cop/minitest/assert_match_test.rb
@@ -175,4 +175,76 @@ class AssertMatchTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_neither_receiver_nor_first_argument_is_a_regexp_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert matcher.match?(object)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_receiver_and_arguments_are_string_literals_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert "...".match?("...")
+        end
+      end
+    RUBY
+  end
+
+  def test_does_register_offense_when_receiver_is_a_regexp_literal_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert /.../.match?(object)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(/.../, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match /.../, object
+        end
+      end
+    RUBY
+  end
+
+  def test_does_register_offense_when_first_argument_is_a_regexp_literal_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert object.match?(/.../)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(/.../, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match /.../, object
+        end
+      end
+    RUBY
+  end
+
+  private
+
+  def enable_only_regexp
+    @configuration = RuboCop::Config.new({ 'Minitest/AssertMatch' => { 'OnlyRegexpLiteral' => true } })
+  end
 end

--- a/test/rubocop/cop/minitest/refute_match_test.rb
+++ b/test/rubocop/cop/minitest/refute_match_test.rb
@@ -204,4 +204,76 @@ class RefuteMatchTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_neither_receiver_nor_first_argument_is_a_regexp_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute matcher.match?(object)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_receiver_and_arguments_are_string_literals_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute "...".match?("...")
+        end
+      end
+    RUBY
+  end
+
+  def test_does_register_offense_when_receiver_is_a_regexp_literal_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute /.../.match?(object)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_match(/.../, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_match /.../, object
+        end
+      end
+    RUBY
+  end
+
+  def test_does_register_offense_when_first_argument_is_a_regexp_literal_and_only_regexp_is_enabled
+    enable_only_regexp
+
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute object.match?(/.../)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_match(/.../, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_match /.../, object
+        end
+      end
+    RUBY
+  end
+
+  private
+
+  def enable_only_regexp
+    @configuration = RuboCop::Config.new({ 'Minitest/RefuteMatch' => { 'OnlyRegexpLiteral' => true } })
+  end
 end


### PR DESCRIPTION
`AssertMatch` & `RefuteMatch` enforce

```diff
-assert matcher.match?(object)
+assert_match(matcher, object)
```

and

```diff
-refute matcher.match?(object)
+refute_match(matcher, object)
```

respectively, which use `=~` under the hood. This makes the cops highly susceptible to false positives, in cases where the matcher object responds to `match?`, but not to `=~`

```ruby
class SuitColorMatcher
  BLACK = [:clubs,    :spades]
  RED   = [:diamonds, :hearts]
  SUITS = BLACK + RED

  def initialize(suit)
    raise ArgumentError, suit.inspect unless SUITS.include?(suit)
    @suit = suit
  end

  def match?(other)
    case @suit
    when *BLACK then BLACK.include?(other)
    when *RED   then RED  .include?(other)
    end
  end
end

SuitColorMatcher.new(:clubs).match?(:spades) # => true
SuitColorMatcher.new(:clubs) =~ :spades      # NoMethodError
```

or cases where the matcher object does also respond to `=~`, but in an incompatible way

```ruby
"".match? "" # => true
"" =~ ""     # TypeError
```

Given RuboCop doesn't have runtime type information, the only case we can reliably identify is the case where a `Regexp` literal is used.

Therefore, **this adds an `OnlyRegexpLiteral` config** (false by default), which consumers can enable if their codebase has many false positives.

This provides a way for consumers to address #310, without changing the cop's behavior for everyone.

As part of making this change, a common module is extracted for the implementations of `AssertMatch` and `RefuteMatch`, which are largely identical.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
  _I wasn't sure about this, since this PR isn't changing/fixing the default behavior, it's just adding an option which allows consumers to fix the behavior._
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
  _Likewise, I tagged the change as "new", since it's an new option, and consumers have to opt-in to the new behavior. We could eventually make it the default though._

[1]: https://chris.beams.io/posts/git-commit/
