### PR TITLE
Replace `EnsureNode.body` with `EnsureNode.branch`

### DIFF
--- a/lib/rubocop/cop/minitest/skip_ensure.rb
+++ b/lib/rubocop/cop/minitest/skip_ensure.rb
@@ -86,10 +86,10 @@ module RuboCop
 
         def valid_conditional_skip?(skip_method, ensure_node)
           if_node = skip_method.ancestors.detect(&:if_type?)
-          return false unless ensure_node.body.if_type?
+          return false unless ensure_node.branch.if_type?
 
-          match_keyword = ensure_node.body.if? ? if_node.if? : if_node.unless?
-          match_keyword && ensure_node.body.condition == if_node.condition
+          match_keyword = ensure_node.branch.if? ? if_node.if? : if_node.unless?
+          match_keyword && ensure_node.branch.condition == if_node.condition
         end
       end
     end

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '>= 1.61', '< 2.0'
-  spec.add_dependency 'rubocop-ast', '>= 1.31.1', '< 2.0'
+  spec.add_dependency 'rubocop-ast', '>= 1.36.1', '< 2.0'
 end


### PR DESCRIPTION
`EnsureNode.body` has been deprecated in rubocop/rubocop-ast#337, and will be reimplemented in the next major version of rubocop-ast. In order to prepare for that, existing `EnsureNode.body` calls, which retreive the `ensure` branch of exception handling, have been replaced with `EnsureNode.branch`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/