### PR TITLE
Workaround for a build error with Prism 1.3.0

### DIFF
--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -241,6 +241,8 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_assignments_with_numblocks_are_counted_correctly
+    skip 'It passed with Prism 1.2.0, but started failing with Prism 1.3.0.' if ENV['PARSER_ENGINE'] == 'parser_prism'
+
     assert_offense(<<~RUBY)
       class FooTest < ActiveSupport::TestCase
         test "#render errors include stack traces" do


### PR DESCRIPTION
The following test passed with Prism 1.2.0, but started failing with Prism 1.3.0.

```console
$ bundle exec rake prism_test
(snip)

==> Failures

  1) Failure:
MultipleAssertionsTest#test_assignments_with_numblocks_are_counted_correctly [test/rubocop/cop/minitest/multiple_assertions_test.rb:244]:
--- expected
+++ actual
@@ -1,6 +1,5 @@
 "class FooTest < ActiveSupport::TestCase
   test \"#render errors include stack traces\" do
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test case has too many assertions [9/1].
     err = assert_raises React::ServerRendering::PrerenderError do
       assert_equal _1, 1
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
