### PR TITLE
Load less of minitest in the test support file

### DIFF
--- a/changelog/change_load_less_of_minitest_in_the_test.md
+++ b/changelog/change_load_less_of_minitest_in_the_test.md
@@ -1,0 +1,1 @@
+* [#328](https://github.com/rubocop/rubocop-minitest/pull/328): Remove "minitest/autorun" and "minitest/pride" requirement from "rubocop/minitest/support". ([@bquorning][])

--- a/lib/rubocop/minitest/support.rb
+++ b/lib/rubocop/minitest/support.rb
@@ -3,8 +3,7 @@
 # Require this file to load code that supports testing using Minitest.
 
 require 'rubocop'
-require 'minitest/autorun'
-require 'minitest/pride'
+require 'minitest'
 require_relative 'assert_offense'
 
 Minitest::Test.include RuboCop::Minitest::AssertOffense

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require_relative '../lib/rubocop-minitest'
 
 # Require supporting files exposed for testing.
 require_relative '../lib/rubocop/minitest/support'
+require 'minitest/autorun'
+require 'minitest/pride'
 require 'minitest/proveit'
 
 Minitest::Test.class_eval do


### PR DESCRIPTION
Allow other projects to load "rubocop/minitest/support" without opting in to "minitest/autorun" and 'minitest/pride'.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
