### PR TITLE
Update `add_dependency` of RuboCop to 1.72 for plugin support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.72.0' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.72.1' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/fix_require_rubocop_version_for_plugin.md
+++ b/changelog/fix_require_rubocop_version_for_plugin.md
@@ -1,0 +1,1 @@
+* [#330](https://github.com/rubocop/rubocop-minitest/pull/330): Update `add_dependency` of RuboCop to 1.72 for plugin support. ([@koic][])

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '>= 1.61', '< 2.0'
+  spec.add_dependency 'rubocop', '>= 1.72.1', '< 2.0'
   spec.add_dependency 'rubocop-ast', '>= 1.38.0', '< 2.0'
 end


### PR DESCRIPTION
RuboCop 1.72 or later is required for plugin support.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
