### PR TITLE
Support `it` block parameter in `Minitest` cops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.72.1' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.75.0' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/new_support_itblock_in_minitest_cops.md
+++ b/changelog/new_support_itblock_in_minitest_cops.md
@@ -1,0 +1,1 @@
+* [#331](https://github.com/rubocop/rubocop-minitest/pull/331): Support `it` block parameter in `Rails` cops. ([@koic][])

--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -65,7 +65,7 @@ module RuboCop
             assertions_count_in_branches(node.branches)
           when :rescue
             assertions_count(node.body) + assertions_count_in_branches(node.branches)
-          when :block, :numblock
+          when :block, :numblock, :itblock
             assertions_count(node.body)
           when *RuboCop::AST::Node::ASSIGNMENTS
             assertions_count_in_assignment(node)

--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -230,8 +230,8 @@ module RuboCop
       end
 
       def ruby_version
-        #  Prism supports parsing Ruby 3.3+.
-        ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : RuboCop::TargetRuby::DEFAULT_VERSION
+        # Prism is the default backend parser for Ruby 3.4+.
+        ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : RuboCop::TargetRuby::DEFAULT_VERSION
       end
 
       def parser_engine

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '>= 1.72.1', '< 2.0'
+  spec.add_dependency 'rubocop', '>= 1.75.0', '< 2.0'
   spec.add_dependency 'rubocop-ast', '>= 1.38.0', '< 2.0'
 end

--- a/test/rubocop/cop/minitest/assert_predicate_test.rb
+++ b/test/rubocop/cop/minitest/assert_predicate_test.rb
@@ -145,6 +145,16 @@ class AssertPredicateTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_when_using_assert_with_predicate_method_and_it_parameter
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert([1, 2, 3].any? { some_filter_function it })
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_raise_error_using_assert_with_block
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -45,6 +45,19 @@ class MultipleAssertionsTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_multiple_expectations_with_itblock
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_asserts_two_times
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Test case has too many assertions [2/1].
+          assert_something do
+            assert_equal(it, bar)
+          end
+        end
+      end
+    RUBY
+  end
+
   def test_checks_when_inheriting_some_class_and_class_name_ending_with_test
     assert_offense(<<~RUBY)
       class FooTest < ActiveSupport::TestCase
@@ -257,6 +270,32 @@ class MultipleAssertionsTest < Minitest::Test
             _ = assert_raises React::ServerRendering::PrerenderError do
               assert_equal _1, 1
               assert_equal _1, 1
+            end
+          end
+
+          assert_match(/NonExistentComponent/, err.to_s, "it names the component")
+
+          assert_match(/\n/, err.to_s, "it includes the multi-line backtrace")
+        end
+      end
+    RUBY
+  end
+
+  def test_assignments_with_itblocks_are_counted_correctly
+    assert_offense(<<~RUBY)
+      class FooTest < ActiveSupport::TestCase
+        test "#render errors include stack traces" do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test case has too many assertions [9/1].
+          err = assert_raises React::ServerRendering::PrerenderError do
+            assert_equal it, 1
+
+            assert_raises React::ServerRendering::PrerenderError do
+              assert_equal it, 1
+            end
+
+            _ = assert_raises React::ServerRendering::PrerenderError do
+              assert_equal it, 1
+              assert_equal it, 1
             end
           end
 

--- a/test/rubocop/cop/minitest/refute_predicate_test.rb
+++ b/test/rubocop/cop/minitest/refute_predicate_test.rb
@@ -144,4 +144,14 @@ class RefutePredicateTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_refute_with_predicate_method_and_it_parameter
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute([1, 2, 3].any? { some_filter_function it })
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/return_in_test_case_method_test.rb
+++ b/test/rubocop/cop/minitest/return_in_test_case_method_test.rb
@@ -100,4 +100,20 @@ class ReturnInTestMethodTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_return_inside_itblock
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_foo
+          Foo.class_eval do
+            it.extend(ClassMethods)
+            def foo
+              return 100
+            end
+          end
+          assert_equal 100, Foo.new.foo
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR supports `it` block parameter in `Minitest` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
