### PR TITLE
[Fix #332] Fix false positives for `Minitest/NoAssertions`

### DIFF
--- a/changelog/fix_false_positives_for_minitest_no_assertion_test.md
+++ b/changelog/fix_false_positives_for_minitest_no_assertion_test.md
@@ -1,0 +1,1 @@
+* [#332](https://github.com/rubocop/rubocop-minitest/issues/332): Fix false positives for `Minitest/NoAssertions` when using matcher methods. ([@koic][])

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -87,20 +87,10 @@ module RuboCop
 
         MSG = 'Use `%<preferred>s` instead.'
 
-        VALUE_MATCHERS = %i[
-          must_be_empty must_equal must_be_close_to must_be_within_delta
-          must_be_within_epsilon must_include must_be_instance_of must_be_kind_of
-          must_match must_be_nil must_be must_respond_to must_be_same_as
-          path_must_exist path_wont_exist wont_be_empty wont_equal wont_be_close_to
-          wont_be_within_delta wont_be_within_epsilon wont_include wont_be_instance_of
-          wont_be_kind_of wont_match wont_be_nil wont_be wont_respond_to wont_be_same_as
-        ].freeze
+        VALUE_MATCHERS = MinitestExplorationHelpers::VALUE_MATCHERS
+        BLOCK_MATCHERS = MinitestExplorationHelpers::BLOCK_MATCHERS
 
-        BLOCK_MATCHERS = %i[
-          must_output must_pattern_match must_raise must_be_silent must_throw wont_pattern_match
-        ].freeze
-
-        RESTRICT_ON_SEND = VALUE_MATCHERS + BLOCK_MATCHERS
+        RESTRICT_ON_SEND = MinitestExplorationHelpers::MATCHER_METHODS
 
         # There are aliases for the `_` method - `expect` and `value`
         DSL_METHODS = %i[_ expect value].freeze

--- a/lib/rubocop/cop/minitest/no_assertions.rb
+++ b/lib/rubocop/cop/minitest/no_assertions.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Minitest
       # Checks if test cases contain any assertion calls.
       #
+      # Matchers such as `must_equal` and `wont_match` are also treated as assertion methods.
+      #
       # @example
       #   # bad
       #   class FooTest < Minitest::Test
@@ -16,6 +18,23 @@ module RuboCop
       #   class FooTest < Minitest::Test
       #     def test_the_truth
       #       assert true
+      #     end
+      #   end
+      #
+      #   # bad
+      #   class FooTest < ActiveSupport::TestCase
+      #     describe 'foo' do
+      #       it 'test equal' do
+      #       end
+      #     end
+      #   end
+      #
+      #   # good
+      #   class FooTest < ActiveSupport::TestCase
+      #     describe 'foo' do
+      #       it 'test equal' do
+      #         musts.must_equal expected_musts
+      #       end
       #     end
       #   end
       #

--- a/test/rubocop/cop/minitest/no_assertions_test.rb
+++ b/test/rubocop/cop/minitest/no_assertions_test.rb
@@ -78,6 +78,30 @@ class NoAssertionsTest < Minitest::Test
     RUBY
   end
 
+  def test_register_no_offense_if_test_has_must_be_empty_assertion
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        describe 'foo' do
+          it 'must have good data' do
+            _(invalid_recs).must_be_empty ->{ do_something }
+          end
+        end
+      end
+    RUBY
+  end
+
+  def test_register_no_offense_if_test_has_must_include_assertion
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        describe 'foo' do
+          it 'must include [false, true]' do
+            value([false, true]).must_include value
+          end
+        end
+      end
+    RUBY
+  end
+
   def test_register_no_offense_for_unrelated_methods
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
This PR fixes false positives for `Minitest/NoAssertions` when using matcher methods.

Resolves #332

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
