### PR TITLE
Fix minitest extension for the cop generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 
 require 'rubocop/rake_task'
 require 'rake/testtask'
-require_relative 'lib/rubocop/cop/generator'
+require 'rubocop/cop/minitest_generator'
 
 # JRuby and Windows don't support fork, so we can't use minitest-queue.
 if RUBY_ENGINE == 'jruby' || RuboCop::Platform.windows?

--- a/changelog/fix_fix_minitest_extension_for_the_cop.md
+++ b/changelog/fix_fix_minitest_extension_for_the_cop.md
@@ -1,0 +1,1 @@
+* [#334](https://github.com/rubocop/rubocop-minitest/issues/334): Fix minitest extension for the cop generator. ([@rafaelfranca][])

--- a/lib/rubocop/cop/minitest_generator.rb
+++ b/lib/rubocop/cop/minitest_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require 'rubocop/cop/generator'
+
 module RuboCop
   module Cop
     # Source and test generator for new cops
     #
     # This generator will take a cop name and generate a source file
     # and test file when given a valid qualified cop name.
-    class Generator
+    module MinitestGenerator
       TEST_TEMPLATE = <<~TEST
         # frozen_string_literal: true
 
@@ -48,3 +50,5 @@ module RuboCop
     end
   end
 end
+
+RuboCop::Cop::Generator.include(RuboCop::Cop::MinitestGenerator)


### PR DESCRIPTION
Instead of reopening the Generator class in a file with the same name of the Generator class in the main rubocop gem, we are now defining a module that get included in the Generator class, defined in a different file path, specific for this minitest plugin.

This allows rubocop plugins that want to use minitest to test their code to be able to generate their own cops using the minitest extension.

Fixes #334.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
