### PR TITLE
[Fix #321] Fix false positives for `Minitest/MultipleAssertions` when the assertion has a receiver

### DIFF
--- a/changelog/fix_false_positives_multiple_assertions_receiver.md
+++ b/changelog/fix_false_positives_multiple_assertions_receiver.md
@@ -1,0 +1,1 @@
+* [#321](https://github.com/rubocop/rubocop-minitest/issues/321): Fix false positives for `Minitest/MultipleAssertions` when the assertion has a receiver. ([@earlopain][])

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -114,21 +114,23 @@ module RuboCop
         end
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
       def assertion_method?(node)
         return false unless node
         return assertion_method?(node.expression) if node.assignment? && node.respond_to?(:expression)
         return false unless node.type?(:send, :any_block)
 
-        method_name = node.method_name
-        assertion_method = ASSERTION_PREFIXES.any? { |prefix| method_name.start_with?(prefix.to_s) }
-
-        assertion_method || node.method?(:flunk) || MATCHER_METHODS.include?(method_name)
+        assertion_prefix_method?(node) || node.method?(:flunk) || MATCHER_METHODS.include?(node.method_name)
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       def lifecycle_hook_method?(node)
         node.def_type? && LIFECYCLE_HOOK_METHODS.include?(node.method_name)
+      end
+
+      def assertion_prefix_method?(node)
+        return false if node.receiver
+
+        method_name = node.method_name
+        ASSERTION_PREFIXES.any? { |prefix| method_name.start_with?(prefix.to_s) }
       end
     end
   end

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -745,6 +745,16 @@ class MultipleAssertionsTest < Minitest::Test
     RUBY
   end
 
+  def test_does_not_register_offense_with_receiver
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_asserts_once
+          assert_equal(foo, Bar.assert_something)
+        end
+      end
+    RUBY
+  end
+
   private
 
   def configure_max_assertions(max)


### PR DESCRIPTION
Fixes ##321, Closes #322

cc @MatzFan

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
