### PR TITLE
[Fix #315] Make `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` aware of alias methods

### DIFF
--- a/changelog/change_make_minitest_assert_includes_and_refute_includes_aware_of_alias_methods.md
+++ b/changelog/change_make_minitest_assert_includes_and_refute_includes_aware_of_alias_methods.md
@@ -1,0 +1,1 @@
+* [#315](https://github.com/rubocop/rubocop-minitest/issues/315): Make `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` aware of `key?`, `has_key?`, and `member?` alias methods. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -18,7 +18,7 @@ module RuboCop
       class AssertIncludes < Base
         extend MinitestCopRule
 
-        define_rule :assert, target_method: :include?, preferred_method: :assert_includes
+        define_rule :assert, target_method: %i[include? key? has_key? member?], preferred_method: :assert_includes
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_includes.rb
+++ b/lib/rubocop/cop/minitest/refute_includes.rb
@@ -18,7 +18,7 @@ module RuboCop
       class RefuteIncludes < Base
         extend MinitestCopRule
 
-        define_rule :refute, target_method: :include?, preferred_method: :refute_includes
+        define_rule :refute, target_method: %i[include? key? has_key? member?], preferred_method: :refute_includes
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -22,6 +22,63 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_key
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.key?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_has_key
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.has_key?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_member
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.member?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_assert_with_include_and_message
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_includes_test.rb
+++ b/test/rubocop/cop/minitest/refute_includes_test.rb
@@ -22,6 +22,63 @@ class RefuteIncludesTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_key
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.key?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_has_key
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.has_key?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_member
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.member?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
   def test_registers_offense_when_using_refute_with_include_and_message
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
This PR makes `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` aware of `key?`, `has_key?`, and `member?` alias methods.

Fixes #315.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
