### PR TITLE
Fix Minitest/NonExecutableTestMethod for inconsistent ordered treatment

### DIFF
--- a/changelog/change_nonexecutable_test_method_test_order_dependence.md
+++ b/changelog/change_nonexecutable_test_method_test_order_dependence.md
@@ -1,0 +1,1 @@
+* [#345](https://github.com/rubocop/rubocop-minitest/pull/345): Fix false positives and negatives in `Minitest/NonExecutableTestMethod` for nested test classes and for test methods defined before the test class. ([@amckinnie][])

--- a/lib/rubocop/cop/minitest/non_executable_test_method.rb
+++ b/lib/rubocop/cop/minitest/non_executable_test_method.rb
@@ -31,7 +31,8 @@ module RuboCop
 
         def on_def(node)
           return if !test_method?(node) || !use_test_class?
-          return if node.left_siblings.none? { |sibling| possible_test_class?(sibling) }
+          return if inside_test_class?(node)
+          return if (node.left_siblings + node.right_siblings).none? { |sibling| possible_test_class?(sibling) }
 
           add_offense(node)
         end
@@ -42,6 +43,10 @@ module RuboCop
           root_node = processed_source.ast
 
           root_node.each_descendant(:class).any? { |class_node| test_class?(class_node) }
+        end
+
+        def inside_test_class?(node)
+          node.each_ancestor(:class).any? { |class_node| test_class?(class_node) }
         end
 
         def possible_test_class?(node)


### PR DESCRIPTION
## Problem

Minitest/NonExecutableTestMethod treats the order tests appear relative to test classes inconsistently. This shows up in a couple of ways:
- A test method adjacent to a test class fails the cop if the test is after the test class, but not before
- A test method adjacent to a test class both within a parent test class fails if the test follows the test class, but not if it precedes it

## Fix

To make the cop treat the ordering the same, checks are added to
- Check left and right siblings of a node identified as a test method for test classes
- Check ancestors of a node identified as a test method for the existence of a test class

## Notes

### ~Breaking~

~This change is breaking because it applies a stricter criteria on the first case, where tests before test classes will now trigger a failure~

### Further Investigation

A way around this if you use the Minitest::Spec DSL `describe` blocks (or aliases) exists for the nested class issue; this indicates that these are treated differently from classes, at least for this cop. If this is a concern, it may be good to figure out how to treat these as classes in helper methods (if Minitest::Spec DSL is in use).   

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
