### PR TITLE
Fix false positives in `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` cops

### DIFF
--- a/changelog/fix_false_positive_for_assert_includes_and_refute_includes_cops.md
+++ b/changelog/fix_false_positive_for_assert_includes_and_refute_includes_cops.md
@@ -1,0 +1,1 @@
+* [#347](https://github.com/rubocop/rubocop-minitest/pull/347): Fix false positives in `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` cops. ([@koic][])

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -18,7 +18,7 @@ module RuboCop
       class AssertIncludes < Base
         extend MinitestCopRule
 
-        define_rule :assert, target_method: %i[include? key? has_key? member?], preferred_method: :assert_includes
+        define_rule :assert, target_method: %i[include? member?], preferred_method: :assert_includes
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_includes.rb
+++ b/lib/rubocop/cop/minitest/refute_includes.rb
@@ -18,7 +18,7 @@ module RuboCop
       class RefuteIncludes < Base
         extend MinitestCopRule
 
-        define_rule :refute, target_method: %i[include? key? has_key? member?], preferred_method: :refute_includes
+        define_rule :refute, target_method: %i[include? member?], preferred_method: :refute_includes
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -22,44 +22,6 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_key
-    assert_offense(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert(collection.key?(object))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_includes(collection, object)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_assert_with_has_key
-    assert_offense(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert(collection.has_key?(object))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          assert_includes(collection, object)
-        end
-      end
-    RUBY
-  end
-
   def test_registers_offense_when_using_assert_with_member
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
@@ -160,6 +122,26 @@ class AssertIncludesTest < Minitest::Test
         def test_do_something
           collection = []
           assert(collection)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assert_with_key
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.key?(object))
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assert_with_has_key
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.has_key?(object))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_includes_test.rb
+++ b/test/rubocop/cop/minitest/refute_includes_test.rb
@@ -22,44 +22,6 @@ class RefuteIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_with_key
-    assert_offense(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute(collection.key?(object))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_includes(collection, object)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_refute_with_has_key
-    assert_offense(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute(collection.has_key?(object))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY)
-      class FooTest < Minitest::Test
-        def test_do_something
-          refute_includes(collection, object)
-        end
-      end
-    RUBY
-  end
-
   def test_registers_offense_when_using_refute_with_member
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
@@ -149,6 +111,26 @@ class RefuteIncludesTest < Minitest::Test
       class FooTest < Minitest::Test
         def test_do_something
           refute(collection.end_with?(string))
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_refute_with_key
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.key?(object))
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_refute_with_has_key
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.has_key?(object))
         end
       end
     RUBY


### PR DESCRIPTION
This PR fixes false positives in `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` cops for `key?` and `has_key?` used with `assert` or `refute`.

Since `member?` is an alias of `include?`, it can be included as a target for replacement with `assert_includes`. 
https://github.com/minitest/minitest/blob/v6.0.2/lib/minitest/assertions.rb#L241-L249

However, replacing `key?` and `has_key?` with `assert_includes` may undermine the user’s intended meaning. Therefore, `key?` and `has_key?` should not be detected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
