### PR TITLE
Remove `test-queue` to reduce time taken to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
   main:
     name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
-    env:
-      # See https://github.com/tmm1/test-queue#environment-variables
-      TEST_QUEUE_WORKERS: 2
     strategy:
       fail-fast: false
       matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'prism'
 gem 'rake'
 gem 'rubocop', github: 'rubocop/rubocop'
 gem 'rubocop-performance', '~> 1.24.0'
-gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 local_gemfile = File.expand_path('Gemfile.local', __dir__)

--- a/Rakefile
+++ b/Rakefile
@@ -19,18 +19,9 @@ require 'rubocop/rake_task'
 require 'rake/testtask'
 require 'rubocop/cop/minitest_generator'
 
-# JRuby and Windows don't support fork, so we can't use minitest-queue.
-if RUBY_ENGINE == 'jruby' || RuboCop::Platform.windows?
-  Rake::TestTask.new do |t|
-    t.libs << 'test'
-    t.libs << 'lib'
-    t.test_files = FileList['test/**/*_test.rb']
-  end
-else
-  desc 'Run tests'
-  task :test do
-    sh("bundle exec minitest-queue #{Dir.glob('test/**/*_test.rb').shelljoin}")
-  end
+desc 'Run tests'
+task :test do
+  sh("bundle exec ruby -Ilib:test #{Dir.glob('test/**/*_test.rb').shelljoin}")
 end
 
 desc 'Run tests with Prism'


### PR DESCRIPTION
For a small repository, queue is an overhead. Running minitest tests directly are much more performant.

On my machine: `time bundle exec rake test`
test-queue takes `16.44s` 
direct minitest takes `1.50s`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
