### PR TITLE
Use Minitest's TestTask to run all tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,13 +16,10 @@ rescue Bundler::BundlerError => e
 end
 
 require 'rubocop/rake_task'
-require 'rake/testtask'
 require 'rubocop/cop/minitest_generator'
 
-desc 'Run tests'
-task :test do
-  sh("bundle exec ruby -Ilib:test #{Dir.glob('test/**/*_test.rb').shelljoin}")
-end
+require 'minitest/test_task'
+Minitest::TestTask.create
 
 desc 'Run tests with Prism'
 task :prism_test do


### PR DESCRIPTION
After #349 we were accidentally only running one test file. With this change we are back to running all tests again.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
