### PR TITLE
Speed up global_expectations_test

### DIFF
--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -6,6 +6,7 @@ class GlobalExpectationsTest < Minitest::Test
   UNDERSCORE_ANY_STYLES = %i[_ any].freeze
   VALUE_ANY_STYLES = %i[value any].freeze
   EXPECT_ANY_STYLES = %i[expect any].freeze
+  ALL_CONFIG = YAML.safe_load(File.read("#{__dir__}/../../../../config/default.yml")).freeze
 
   def setup
     configure_enforced_style(style)
@@ -506,10 +507,9 @@ class GlobalExpectationsTest < Minitest::Test
   private
 
   def configure_enforced_style(style)
-    all_config = YAML.safe_load(File.read("#{__dir__}/../../../../config/default.yml")).freeze
-    cop_config = all_config['Minitest/GlobalExpectations']
+    cop_config = ALL_CONFIG['Minitest/GlobalExpectations']
     cop_config = cop_config.merge('EnforcedStyle' => style)
-    all_config = all_config.merge('Minitest/GlobalExpectations' => cop_config)
+    all_config = ALL_CONFIG.merge('Minitest/GlobalExpectations' => cop_config)
     config = RuboCop::Config.new(all_config)
     @cop = RuboCop::Cop::Minitest::GlobalExpectations.new(config)
     @preferred_method = style == :any ? :_ : style


### PR DESCRIPTION
The `#configure_enforced_style` method is called 1880 times, reading the same YAML file 1880 times. We can optimize by extracting it to a constant so it's read only once.

Test runtime improved on my machine (Apple M1) from 3.6s → 1.8s[^1] (Minitest's own reporting, so add ~2 seconds of boot time).

[^1]: That benchmark was made when all tests are run – see #351.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
