### PR TITLE
Add `RuboCop::TestCase` as a stable API for testing custom cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,96 @@ Minitest/AssertNil:
     - test/my_file_to_ignore_test.rb
 ```
 
+## Testing your own cops
+
+This gem provides `RuboCop::TestCase`, a base test case class for testing custom cops with Minitest.
+Require `rubocop/minitest/support` in your test helper, then inherit from `RuboCop::TestCase` to get
+the `assert_offense`, `assert_correction`, `assert_no_corrections`, and `assert_no_offenses` assertions:
+
+```ruby
+require 'rubocop/minitest/support'
+
+module CustomCops
+  class MyCopTest < RuboCop::TestCase
+    def test_registers_offense
+      assert_offense(<<~RUBY)
+        bad_method
+        ^^^^^^^^^^ Use `good_method` instead of `bad_method`.
+      RUBY
+
+      assert_correction(<<~RUBY)
+        good_method
+      RUBY
+    end
+
+    def test_does_not_register_offense
+      assert_no_offenses(<<~RUBY)
+        good_method
+      RUBY
+    end
+  end
+end
+```
+
+The cop under test is derived from the test class name: `CustomCops::MyCopTest` resolves
+`CustomCops::MyCop`, then `RuboCop::Cop::Minitest::MyCop`. Define a `cop_class` method in
+the test class to specify the cop explicitly:
+
+```ruby
+class MyCopTest < RuboCop::TestCase
+  private
+
+  def cop_class
+    CustomCops::MyCop
+  end
+end
+```
+
+The configuration for the cop under test and the target Ruby version can be specified
+by overriding `cop_config`, `other_cops`, or `target_ruby_version` in the test class:
+
+```ruby
+class MyCopTest < RuboCop::TestCase
+  private
+
+  def cop_config
+    { 'Max' => 1 }
+  end
+
+  def target_ruby_version
+    3.0
+  end
+end
+```
+
+To change them for a single test, assign them in the test method. This makes it
+possible for tests targeting different Ruby versions to live in the same test class:
+
+```ruby
+class MyCopTest < RuboCop::TestCase
+  def test_registers_offense_on_ruby31
+    self.target_ruby_version = 3.1
+
+    assert_offense(<<~RUBY)
+      bad_method
+      ^^^^^^^^^^ Use `good_method` instead of `bad_method`.
+    RUBY
+  end
+
+  def test_does_not_register_offense_on_ruby30
+    self.target_ruby_version = 3.0
+
+    assert_no_offenses(<<~RUBY)
+      bad_method
+    RUBY
+  end
+end
+```
+
+The default configuration of extensions registered as [lint_roller](https://github.com/standardrb/lint_roller) plugins
+is applied automatically. For other extensions, call `RuboCop::ConfigLoader.inject_defaults!('path/to/default.yml')`
+in your test helper.
+
 ## Documentation
 
 You can read a lot more about RuboCop Minitest in its [official docs](https://docs.rubocop.org/rubocop-minitest/).

--- a/changelog/change_remove_cop_argument_from_inspect_source_and_investigate.md
+++ b/changelog/change_remove_cop_argument_from_inspect_source_and_investigate.md
@@ -1,0 +1,1 @@
+* [#278](https://github.com/rubocop/rubocop-minitest/pull/278): **(Breaking)** Remove the cop argument from `inspect_source` and `investigate` in the Minitest test support; the cop under test is now resolved automatically. The test configuration now merges the default configuration for the cop under test and sets `AllCops: TargetRubyVersion` explicitly. ([@koic][])

--- a/changelog/new_add_rubocop_test_case.md
+++ b/changelog/new_add_rubocop_test_case.md
@@ -1,0 +1,1 @@
+* [#278](https://github.com/rubocop/rubocop-minitest/pull/278): Add new `RuboCop::TestCase` as a stable API for testing custom cops with Minitest. The cop under test is derived from the test class name and can be configured with `cop_class`, `cop_config`, `other_cops`, and `target_ruby_version`. ([@koic][])

--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -71,17 +71,135 @@ module RuboCop
     #
     #   assert_no_corrections
     #
+    # The cop under test is derived from the test class name: `FooTest` resolves
+    # the `Foo` constant in the test class's namespace, then `RuboCop::Cop::Minitest::Foo`.
+    # Define a `cop_class` method in the test class to specify the cop explicitly:
+    #
+    #   class AssertNilTest < RuboCop::TestCase
+    #     private
+    #
+    #     def cop_class
+    #       RuboCop::Cop::Minitest::AssertNil
+    #     end
+    #   end
+    #
+    # The configuration for the cop under test and the target Ruby version can be specified
+    # by overriding `cop_config`, `other_cops`, or `target_ruby_version` in the test class:
+    #
+    # @example `cop_config` and `target_ruby_version`
+    #
+    #   class MultipleAssertionsTest < RuboCop::TestCase
+    #     private
+    #
+    #     def cop_config
+    #       { 'Max' => 1 }
+    #     end
+    #
+    #     def target_ruby_version
+    #       3.0
+    #     end
+    #   end
+    #
+    # To change them for a single test, assign them in the test method.
+    # This makes it possible for tests targeting different Ruby versions to live in the same test class:
+    #
+    # @example assigning `target_ruby_version` per test
+    #
+    #   class MyCopTest < RuboCop::TestCase
+    #     def test_registers_offense_on_ruby31
+    #       self.target_ruby_version = 3.1
+    #
+    #       assert_offense(<<~RUBY)
+    #         ...
+    #       RUBY
+    #     end
+    #
+    #     def test_does_not_register_offense_on_ruby30
+    #       self.target_ruby_version = 3.0
+    #
+    #       assert_no_offenses(<<~RUBY)
+    #         ...
+    #       RUBY
+    #     end
+    #   end
+    #
     # rubocop:disable Metrics/ModuleLength
     module AssertOffense
+      PLUGIN_INTEGRATION_MUTEX = Mutex.new
+      private_constant :PLUGIN_INTEGRATION_MUTEX
+
+      class << self
+        # Makes the default configuration of extensions registered as lint_roller plugins visible
+        # through `RuboCop::ConfigLoader.default_configuration`.
+        # Guarded by a mutex so that parallel test threads reaching their first assertion at the same time
+        # do not integrate plugins twice or race on the lazy initialization of the default configuration.
+        def integrate_plugins!
+          PLUGIN_INTEGRATION_MUTEX.synchronize do
+            next if @integrated_plugins
+
+            plugins = Gem.loaded_specs.filter_map do |feature_name, feature_specification|
+              feature_name if feature_specification.metadata['default_lint_roller_plugin']
+            end
+            RuboCop::Plugin.integrate_plugins(RuboCop::Config.new, plugins)
+
+            @integrated_plugins = true
+          end
+        end
+      end
+
       private
 
       def cop
         @cop ||= begin
-          cop_name = self.class.to_s.delete_suffix('Test')
-          raise "Cop not defined: #{cop_name}" unless RuboCop::Cop::Minitest.const_defined?(cop_name)
+          unless cop_class
+            raise "Could not determine the cop class under test from `#{self.class}`. " \
+                  'The cop class is derived from the test class name (e.g. `FooTest` resolves `Foo` ' \
+                  "in the test class's namespace, then `RuboCop::Cop::Minitest::Foo`). " \
+                  'Define a `cop_class` method in your test class to specify it explicitly.'
+          end
 
-          RuboCop::Cop::Minitest.const_get(cop_name).new(configuration)
+          cop_class.new(configuration)
         end
+      end
+
+      def cop_class
+        @cop_class ||= derive_cop_class
+      end
+
+      def cop_class=(cop_class)
+        @cop_class = cop_class
+
+        reset_memoization
+      end
+
+      def derive_cop_class
+        klass = self.class
+
+        while klass && klass != ::Minitest::Test
+          candidate = derive_cop_class_from_name(klass.name)
+          return candidate if candidate
+
+          klass = klass.superclass
+        end
+
+        nil
+      end
+
+      def derive_cop_class_from_name(test_class_name)
+        return unless test_class_name
+
+        cop_name = test_class_name.delete_suffix('Test')
+        return if cop_name.empty?
+
+        constant_from(Object, cop_name) || constant_from(RuboCop::Cop::Minitest, cop_name.split('::').last)
+      end
+
+      def constant_from(namespace, constant_name)
+        return unless namespace.const_defined?(constant_name)
+
+        candidate = namespace.const_get(constant_name)
+
+        candidate if candidate.is_a?(Class) && candidate < RuboCop::Cop::Base
       end
 
       def format_offense(source, **replacements)
@@ -97,7 +215,7 @@ module RuboCop
       def assert_no_offenses(source, file = nil)
         setup_assertion
 
-        offenses = inspect_source(source, cop, file)
+        offenses = inspect_source(source, file)
 
         expected_annotations = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
         actual_annotations = expected_annotations.with_offense_annotations(offenses)
@@ -180,19 +298,15 @@ module RuboCop
         RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
       end
 
-      def inspect_source(source, cop, file = nil)
+      def inspect_source(source, file = nil)
         processed_source = parse_source!(source, file)
         raise 'Error parsing example code' unless processed_source.valid_syntax?
 
         _investigate(cop, processed_source)
       end
 
-      def investigate(cop, processed_source)
-        needed = Hash.new { |h, k| h[k] = [] }
-        Array(cop.class.joining_forces).each { |force| needed[force] << cop }
-        forces = needed.map do |force_class, joining_cops|
-          force_class.new(joining_cops)
-        end
+      def investigate(processed_source)
+        forces = Array(cop.class.joining_forces).map { |force_class| force_class.new([cop]) }
 
         commissioner = RuboCop::Cop::Commissioner.new([cop], forces, raise_error: true)
         commissioner.investigate(processed_source)
@@ -206,7 +320,7 @@ module RuboCop
           file = file.path
         end
 
-        processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file, parser_engine: parser_engine)
+        processed_source = RuboCop::ProcessedSource.new(source, target_ruby_version, file, parser_engine: parser_engine)
         processed_source.config = configuration
         processed_source.registry = registry
         processed_source
@@ -216,22 +330,71 @@ module RuboCop
         @configuration ||= if defined?(config)
                              config
                            else
-                             RuboCop::Config.new({}, "#{Dir.pwd}/.rubocop.yml")
+                             RuboCop::Config.new(configuration_hash, "#{Dir.pwd}/.rubocop.yml")
                            end
+      end
+
+      def configuration_hash
+        RuboCop::Minitest::AssertOffense.integrate_plugins!
+
+        hash = { 'AllCops' => { 'TargetRubyVersion' => target_ruby_version } }
+        if cop_class
+          hash[cop_class.cop_name] = RuboCop::ConfigLoader.default_configuration.for_cop(cop_class).merge(
+            'Enabled' => true, 'AutoCorrect' => 'always'
+          ).merge(cop_config)
+        end
+
+        hash.merge(other_cops)
+      end
+
+      def cop_config
+        @cop_config || {}
+      end
+
+      def cop_config=(config)
+        @cop_config = config
+
+        reset_memoization
+      end
+
+      def other_cops
+        @other_cops || {}
+      end
+
+      def other_cops=(other_cops)
+        @other_cops = other_cops
+
+        reset_memoization
       end
 
       def registry
         @registry ||= begin
           cops = configuration.keys.map { |cop| RuboCop::Cop::Registry.global.find_by_cop_name(cop) }
-          cops << cop_class if defined?(cop_class) && !cops.include?(cop_class)
+          cops << cop_class if cop_class && !cops.include?(cop_class)
           cops.compact!
           RuboCop::Cop::Registry.new(cops)
         end
       end
 
-      def ruby_version
+      def target_ruby_version
         # Prism is the default backend parser for Ruby 3.4+.
-        ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : RuboCop::TargetRuby::DEFAULT_VERSION
+        @target_ruby_version || (ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : RuboCop::TargetRuby::DEFAULT_VERSION)
+      end
+
+      def target_ruby_version=(version)
+        @target_ruby_version = version
+
+        reset_memoization
+      end
+
+      def reset_memoization
+        @cop = nil
+        @configuration = nil
+        @registry = nil
+      end
+
+      def ruby_version
+        target_ruby_version
       end
 
       def parser_engine

--- a/lib/rubocop/minitest/support.rb
+++ b/lib/rubocop/minitest/support.rb
@@ -5,5 +5,6 @@
 require 'rubocop'
 require 'minitest'
 require_relative 'assert_offense'
+require_relative '../test_case'
 
 Minitest::Test.include RuboCop::Minitest::AssertOffense

--- a/lib/rubocop/test_case.rb
+++ b/lib/rubocop/test_case.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'minitest'
+require_relative 'minitest/assert_offense'
+
+module RuboCop
+  # Base test case class for testing custom cops with Minitest.
+  #
+  # @example Usage
+  #
+  #   class MyCopTest < RuboCop::TestCase
+  #     def test_registers_offense
+  #       assert_offense(<<~RUBY)
+  #         bad_method
+  #         ^^^^^^^^^^ Use `good_method` instead of `bad_method`.
+  #       RUBY
+  #
+  #       assert_correction(<<~RUBY)
+  #         good_method
+  #       RUBY
+  #     end
+  #   end
+  #
+  # See the documentation of `RuboCop::Minitest::AssertOffense` for details.
+  class TestCase < ::Minitest::Test
+    include RuboCop::Minitest::AssertOffense
+  end
+end

--- a/test/rubocop/cop/minitest/assert_empty_literal_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_literal_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertEmptyLiteralTest < Minitest::Test
+class AssertEmptyLiteralTest < RuboCop::TestCase
   def test_registers_offense_when_asserting_empty_array
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertEmptyTest < Minitest::Test
+class AssertEmptyTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_empty
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_equal_test.rb
+++ b/test/rubocop/cop/minitest/assert_equal_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertEqualTest < Minitest::Test
+class AssertEqualTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_operator_with_string
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_in_delta_test.rb
+++ b/test/rubocop/cop/minitest/assert_in_delta_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertInDeltaTest < Minitest::Test
+class AssertInDeltaTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_with_float_as_expected_value
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertIncludesTest < Minitest::Test
+class AssertIncludesTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_include
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_instance_of_test.rb
+++ b/test/rubocop/cop/minitest/assert_instance_of_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertInstanceOfTest < Minitest::Test
+class AssertInstanceOfTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_instance_of
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_kind_of_test.rb
+++ b/test/rubocop/cop/minitest/assert_kind_of_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertKindOfTest < Minitest::Test
+class AssertKindOfTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_kind_of
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_match_test.rb
+++ b/test/rubocop/cop/minitest/assert_match_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertMatchTest < Minitest::Test
+class AssertMatchTest < RuboCop::TestCase
   %i[match match? =~].each do |matcher|
     define_method("test_registers_offense_when_using_assert_with_#{matcher}") do
       assert_offense(<<~RUBY, matcher: matcher)
@@ -62,7 +62,7 @@ class AssertMatchTest < Minitest::Test
     end
 
     define_method("test_registers_offense_when_using_assert_with_#{matcher}_and_message") do
-      assert_offense(<<~RUBY, @cop, matcher: matcher)
+      assert_offense(<<~RUBY, matcher: matcher)
         class FooTest < Minitest::Test
           def test_do_something
             assert(matcher.#{matcher}(object), 'message')

--- a/test/rubocop/cop/minitest/assert_nil_test.rb
+++ b/test/rubocop/cop/minitest/assert_nil_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertNilTest < Minitest::Test
+class AssertNilTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_with_nil
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_offense_test.rb
+++ b/test/rubocop/cop/minitest/assert_offense_test.rb
@@ -16,7 +16,7 @@ class AssertOffenseTest
         RUBY
       end
 
-      assert_includes error.message, 'Cop not defined'
+      assert_includes error.message, 'Could not determine the cop class under test'
     end
   end
 end

--- a/test/rubocop/cop/minitest/assert_operator_test.rb
+++ b/test/rubocop/cop/minitest/assert_operator_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertOperatorTest < Minitest::Test
+class AssertOperatorTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_operator_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_output_test.rb
+++ b/test/rubocop/cop/minitest/assert_output_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertOutputTest < Minitest::Test
+class AssertOutputTest < RuboCop::TestCase
   def test_registers_offense_when_mutating_output_global_variable
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_path_exists_test.rb
+++ b/test/rubocop/cop/minitest/assert_path_exists_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertPathExistsTest < Minitest::Test
+class AssertPathExistsTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_file_exist
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_predicate_test.rb
+++ b/test/rubocop/cop/minitest/assert_predicate_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertPredicateTest < Minitest::Test
+class AssertPredicateTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_with_predicate_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_raises_compound_body_test.rb
+++ b/test/rubocop/cop/minitest/assert_raises_compound_body_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertRaisesCompoundBodyTest < Minitest::Test
+class AssertRaisesCompoundBodyTest < RuboCop::TestCase
   def test_registers_offense_when_multi_statement_bodies
     assert_offense(<<~RUBY)
       assert_raises(MyError) do

--- a/test/rubocop/cop/minitest/assert_raises_with_regexp_argument_test.rb
+++ b/test/rubocop/cop/minitest/assert_raises_with_regexp_argument_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertRaisesWithRegexpArgumentTest < Minitest::Test
+class AssertRaisesWithRegexpArgumentTest < RuboCop::TestCase
   def test_registers_offense_with_regexp
     assert_offense(<<~RUBY)
       assert_raises(MyError, /some message/) do

--- a/test/rubocop/cop/minitest/assert_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/assert_respond_to_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertRespondToTest < Minitest::Test
+class AssertRespondToTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_calling_respond_to_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_same_test.rb
+++ b/test/rubocop/cop/minitest/assert_same_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertSameTest < Minitest::Test
+class AssertSameTest < RuboCop::TestCase
   def test_registers_offense_when_using_equal
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_silent_test.rb
+++ b/test/rubocop/cop/minitest/assert_silent_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertSilentTest < Minitest::Test
+class AssertSilentTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_output_with_empty_strings
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_truthy_test.rb
+++ b/test/rubocop/cop/minitest/assert_truthy_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertTruthyTest < Minitest::Test
+class AssertTruthyTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_with_true
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_with_expected_argument_test.rb
+++ b/test/rubocop/cop/minitest/assert_with_expected_argument_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertWithExpectedArgumentTest < Minitest::Test
+class AssertWithExpectedArgumentTest < RuboCop::TestCase
   def test_registers_offense_when_second_argument_is_not_a_string
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assertion_in_lifecycle_hook_test.rb
+++ b/test/rubocop/cop/minitest/assertion_in_lifecycle_hook_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class AssertionInLifecycleHookTest < Minitest::Test
+class AssertionInLifecycleHookTest < RuboCop::TestCase
   def test_registers_offense_when_using_bad_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/duplicate_test_run_test.rb
+++ b/test/rubocop/cop/minitest/duplicate_test_run_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class DuplicateTestRunTest < Minitest::Test
+class DuplicateTestRunTest < RuboCop::TestCase
   def test_registers_offense_when_parent_and_child_have_tests_methods
     assert_offense(<<~RUBY)
       class ParentTest < Minitest::Test

--- a/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
+++ b/test/rubocop/cop/minitest/empty_line_before_assertion_methods_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class EmptyLineBeforeAssertionMethodsTest < Minitest::Test
+class EmptyLineBeforeAssertionMethodsTest < RuboCop::TestCase
   def test_registers_offense_when_using_method_call_before_assertion_method
     assert_offense(<<~RUBY)
       def test_do_something

--- a/test/rubocop/cop/minitest/focus_test.rb
+++ b/test/rubocop/cop/minitest/focus_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class FocusTest < Minitest::Test
+class FocusTest < RuboCop::TestCase
   def test_registers_offense_when_using_direct_focus
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -2,11 +2,10 @@
 
 require_relative '../../../test_helper'
 
-class GlobalExpectationsTest < Minitest::Test
+class GlobalExpectationsTest < RuboCop::TestCase
   UNDERSCORE_ANY_STYLES = %i[_ any].freeze
   VALUE_ANY_STYLES = %i[value any].freeze
   EXPECT_ANY_STYLES = %i[expect any].freeze
-  ALL_CONFIG = YAML.safe_load(File.read("#{__dir__}/../../../../config/default.yml")).freeze
 
   def setup
     configure_enforced_style(style)
@@ -507,11 +506,7 @@ class GlobalExpectationsTest < Minitest::Test
   private
 
   def configure_enforced_style(style)
-    cop_config = ALL_CONFIG['Minitest/GlobalExpectations']
-    cop_config = cop_config.merge('EnforcedStyle' => style)
-    all_config = ALL_CONFIG.merge('Minitest/GlobalExpectations' => cop_config)
-    config = RuboCop::Config.new(all_config)
-    @cop = RuboCop::Cop::Minitest::GlobalExpectations.new(config)
+    self.cop_config = { 'EnforcedStyle' => style.to_s }
     @preferred_method = style == :any ? :_ : style
   end
 end

--- a/test/rubocop/cop/minitest/lifecycle_hooks_order_test.rb
+++ b/test/rubocop/cop/minitest/lifecycle_hooks_order_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class LifecycleHooksOrderTest < Minitest::Test
+class LifecycleHooksOrderTest < RuboCop::TestCase
   def test_registers_offense_when_hooks_are_not_correctly_ordered
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
+++ b/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class LiteralAsActualArgumentTest < Minitest::Test
+class LiteralAsActualArgumentTest < RuboCop::TestCase
   def test_registers_offense_when_actual_is_basic_literal
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
 require_relative '../../../test_helper'
 
-class MultipleAssertionsTest < Minitest::Test
+class MultipleAssertionsTest < RuboCop::TestCase
   def setup
     configure_max_assertions(1)
   end
@@ -333,9 +334,7 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_generates_a_todo_based_on_the_worst_violation
-    skip 'FIXME: The shared `@cop` instance variable causes flaky tests due to state changes.'
-
-    inspect_source(<<-RUBY, @cop, 'test/foo_test.rb')
+    source = <<-RUBY
       class FooTest < Minitest::Test
         def test_asserts_once
           assert_equal(foo, bar)
@@ -350,7 +349,25 @@ class MultipleAssertionsTest < Minitest::Test
       end
     RUBY
 
-    assert_equal({ 'Max' => 4 }, @cop.config_to_allow_offenses[:exclude_limit])
+    # RuboCop >= 1.86.2 tracks exclude limits in tmp files so that
+    # `--auto-gen-config` can run in parallel.
+    # TODO: When support for RuboCop < 1.86.2 ends, this condition can be removed,
+    # keeping only the `RuboCop::ExcludeLimit.tmp_dir` branch.
+    if RuboCop::ExcludeLimit.respond_to?(:tmp_dir=)
+      Dir.mktmpdir do |tmp_dir|
+        RuboCop::ExcludeLimit.tmp_dir = Pathname.new(tmp_dir)
+
+        inspect_source(source, 'test/foo_test.rb')
+
+        assert_equal({ 'Max' => 4 }, RuboCop::ExcludeLimit.read_limits('Minitest/MultipleAssertions'))
+      ensure
+        RuboCop::ExcludeLimit.tmp_dir = nil
+      end
+    else
+      inspect_source(source, 'test/foo_test.rb')
+
+      assert_equal({ 'Max' => 4 }, cop.config_to_allow_offenses[:exclude_limit])
+    end
   end
 
   def test_registers_offense_when_multiple_assertions_in_the_test_block
@@ -576,8 +593,6 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_registers_offense_when_complex_structure_with_multiple_assertions
-    skip 'FIXME: The shared `@cop` instance variable causes flaky tests due to state changes.'
-
     configure_max_assertions(2)
 
     assert_offense(<<~RUBY)
@@ -617,8 +632,6 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_registers_offense_when_complex_structure_with_assignments_and_multiple_assertions
-    skip 'FIXME: The shared `@cop` instance variable causes flaky tests due to state changes.'
-
     configure_max_assertions(2)
 
     assert_offense(<<~RUBY)
@@ -672,8 +685,6 @@ class MultipleAssertionsTest < Minitest::Test
   end
 
   def test_registers_offense_when_complex_multiple_assignment_structure_and_multiple_assertions
-    skip 'FIXME: The shared `@cop` instance variable causes flaky tests due to state changes.'
-
     configure_max_assertions(2)
 
     assert_offense(<<~RUBY)
@@ -758,7 +769,6 @@ class MultipleAssertionsTest < Minitest::Test
   private
 
   def configure_max_assertions(max)
-    cop_config = RuboCop::Config.new('Minitest/MultipleAssertions' => { 'Max' => max })
-    @cop = RuboCop::Cop::Minitest::MultipleAssertions.new(cop_config)
+    self.cop_config = { 'Max' => max }
   end
 end

--- a/test/rubocop/cop/minitest/no_assertions_test.rb
+++ b/test/rubocop/cop/minitest/no_assertions_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class NoAssertionsTest < Minitest::Test
+class NoAssertionsTest < RuboCop::TestCase
   def test_registers_offense_when_no_assertions
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/no_test_cases_test.rb
+++ b/test/rubocop/cop/minitest/no_test_cases_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class NoTestCases < Minitest::Test
+class NoTestCases < RuboCop::TestCase
   def test_registers_offense_for_empty_test_class
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/non_executable_test_method_test.rb
+++ b/test/rubocop/cop/minitest/non_executable_test_method_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class NonExecutableTestMethodTest < Minitest::Test
+class NonExecutableTestMethodTest < RuboCop::TestCase
   def test_registers_offense_when_test_method_is_defined_outside_minitest_test_class
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/non_public_test_method_test.rb
+++ b/test/rubocop/cop/minitest/non_public_test_method_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class NonPublicTestMethodTest < Minitest::Test
+class NonPublicTestMethodTest < RuboCop::TestCase
   def test_registers_offense_when_using_private_test_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/redundant_message_argument_test.rb
+++ b/test/rubocop/cop/minitest/redundant_message_argument_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RedundantMessageArgumentTest < Minitest::Test
+class RedundantMessageArgumentTest < RuboCop::TestCase
   def test_registers_offense_when_using_redundant_message_argument_in_assert
     assert_offense(<<~RUBY)
       assert(test, nil)

--- a/test/rubocop/cop/minitest/refute_empty_test.rb
+++ b/test/rubocop/cop/minitest/refute_empty_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteEmptyTest < Minitest::Test
+class RefuteEmptyTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_empty
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_equal_test.rb
+++ b/test/rubocop/cop/minitest/refute_equal_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteEqualTest < Minitest::Test
+class RefuteEqualTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_not_equal_operator_with_string
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_false_test.rb
+++ b/test/rubocop/cop/minitest/refute_false_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteFalseTest < Minitest::Test
+class RefuteFalseTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_with_false
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_in_delta_test.rb
+++ b/test/rubocop/cop/minitest/refute_in_delta_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteInDeltaTest < Minitest::Test
+class RefuteInDeltaTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_equal_with_float_as_expected_value
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_includes_test.rb
+++ b/test/rubocop/cop/minitest/refute_includes_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteIncludesTest < Minitest::Test
+class RefuteIncludesTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_include
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_instance_of_test.rb
+++ b/test/rubocop/cop/minitest/refute_instance_of_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteInstanceOfTest < Minitest::Test
+class RefuteInstanceOfTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_instance_of
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_kind_of_test.rb
+++ b/test/rubocop/cop/minitest/refute_kind_of_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteKindOfTest < Minitest::Test
+class RefuteKindOfTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_kind_of
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_match_test.rb
+++ b/test/rubocop/cop/minitest/refute_match_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteMatchTest < Minitest::Test
+class RefuteMatchTest < RuboCop::TestCase
   %i[match match? =~].each do |matcher|
     define_method("test_registers_offense_when_using_refute_with_#{matcher}") do
       assert_offense(<<~RUBY, matcher: matcher)

--- a/test/rubocop/cop/minitest/refute_nil_test.rb
+++ b/test/rubocop/cop/minitest/refute_nil_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteNilTest < Minitest::Test
+class RefuteNilTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_equal_with_nil
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_operator_test.rb
+++ b/test/rubocop/cop/minitest/refute_operator_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteOperatorTest < Minitest::Test
+class RefuteOperatorTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_operator_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_path_exists_test.rb
+++ b/test/rubocop/cop/minitest/refute_path_exists_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefutePathExistsTest < Minitest::Test
+class RefutePathExistsTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_file_exist
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_predicate_test.rb
+++ b/test/rubocop/cop/minitest/refute_predicate_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefutePredicateTest < Minitest::Test
+class RefutePredicateTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_with_predicate_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/refute_respond_to_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteRespondToTest < Minitest::Test
+class RefuteRespondToTest < RuboCop::TestCase
   def test_registers_offense_when_using_refute_calling_respond_to_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_same_test.rb
+++ b/test/rubocop/cop/minitest/refute_same_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class RefuteSameTest < Minitest::Test
+class RefuteSameTest < RuboCop::TestCase
   def test_registers_offense_when_using_equal
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/return_in_test_case_method_test.rb
+++ b/test/rubocop/cop/minitest/return_in_test_case_method_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class ReturnInTestMethodTest < Minitest::Test
+class ReturnInTestMethodTest < RuboCop::TestCase
   def test_registers_offense_when_using_return_inside_test_method
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/skip_ensure_test.rb
+++ b/test/rubocop/cop/minitest/skip_ensure_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class SkipEnsureTest < Minitest::Test
+class SkipEnsureTest < RuboCop::TestCase
   def test_registers_offense_when_using_skip_in_the_method_body
     assert_offense(<<~RUBY)
       def test_skip

--- a/test/rubocop/cop/minitest/skip_without_reason_test.rb
+++ b/test/rubocop/cop/minitest/skip_without_reason_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class SkipWithoutReasonTest < Minitest::Test
+class SkipWithoutReasonTest < RuboCop::TestCase
   def test_registers_offense_when_skip_without_reason
     assert_offense(<<~RUBY)
       skip

--- a/test/rubocop/cop/minitest/test_file_name_test.rb
+++ b/test/rubocop/cop/minitest/test_file_name_test.rb
@@ -2,9 +2,9 @@
 
 require_relative '../../../test_helper'
 
-class TestFileNameTest < Minitest::Test
+class TestFileNameTest < RuboCop::TestCase
   def test_registers_offense_for_invalid_path
-    offenses = inspect_source(<<~RUBY, cop, 'lib/foo.rb')
+    offenses = inspect_source(<<~RUBY, 'lib/foo.rb')
       class FooTest < Minitest::Test
       end
     RUBY
@@ -15,7 +15,7 @@ class TestFileNameTest < Minitest::Test
   end
 
   def test_registers_offense_for_namespaced_invalid_path
-    offenses = inspect_source(<<~RUBY, cop, 'lib/foo/bar.rb')
+    offenses = inspect_source(<<~RUBY, 'lib/foo/bar.rb')
       module Foo
         class BarTest < Minitest::Test
         end

--- a/test/rubocop/cop/minitest/test_method_name_test.rb
+++ b/test/rubocop/cop/minitest/test_method_name_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class TestMethodNameTest < Minitest::Test
+class TestMethodNameTest < RuboCop::TestCase
   def test_registers_offense_when_test_method_without_prefix
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/unreachable_assertion_test.rb
+++ b/test/rubocop/cop/minitest/unreachable_assertion_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class UnreachableAssertionTest < Minitest::Test
+class UnreachableAssertionTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_equal_at_bottom_of_assert_raises_block
     assert_offense(<<~RUBY)
       assert_raises FooError do

--- a/test/rubocop/cop/minitest/unspecified_exception_test.rb
+++ b/test/rubocop/cop/minitest/unspecified_exception_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class UnspecifiedExceptionTest < Minitest::Test
+class UnspecifiedExceptionTest < RuboCop::TestCase
   def test_registers_offense_when_using_assert_raises_without_exception
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/useless_assertion_test.rb
+++ b/test/rubocop/cop/minitest/useless_assertion_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../test_helper'
 
-class UselessAssertionTest < Minitest::Test
+class UselessAssertionTest < RuboCop::TestCase
   %i[assert refute assert_nil refute_nil assert_not assert_empty refute_empty].each do |matcher|
     define_method("test_#{matcher}_registers_offense_when_using_literals") do
       assert_offense(<<~RUBY, matcher: matcher)

--- a/test/rubocop/test_case_test.rb
+++ b/test/rubocop/test_case_test.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module CustomCops
+  class UseFoo < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+
+    MSG = 'Use `foo` instead of `bar`.'
+
+    def on_send(node)
+      return unless node.method?(:bar)
+
+      add_offense(node) do |corrector|
+        corrector.replace(node, 'foo')
+      end
+    end
+  end
+
+  class UseFooTest < RuboCop::TestCase
+    def test_derives_cop_class_from_test_class_namespace
+      assert_equal(CustomCops::UseFoo, cop_class)
+    end
+
+    def test_registers_offense_and_corrects
+      assert_offense(<<~RUBY)
+        bar
+        ^^^ Use `foo` instead of `bar`.
+      RUBY
+
+      assert_correction(<<~RUBY)
+        foo
+      RUBY
+    end
+
+    def test_inspect_source_uses_the_cop_under_test
+      offenses = inspect_source('bar')
+
+      assert_equal(1, offenses.size)
+      assert_equal('Use `foo` instead of `bar`.', offenses.first.message)
+    end
+
+    def test_inspect_source_accepts_file_path
+      offenses = inspect_source('bar', 'lib/example.rb')
+
+      assert_equal(1, offenses.size)
+    end
+  end
+end
+
+class RuboCopTestCaseCopResolutionTest < RuboCop::TestCase
+  def test_resolves_namespaced_cop_from_test_class_name
+    assert_equal(CustomCops::UseFoo, derive_cop_class_from_name('CustomCops::UseFooTest'))
+  end
+
+  def test_falls_back_to_rubocop_cop_minitest_namespace
+    assert_equal(RuboCop::Cop::Minitest::AssertNil, derive_cop_class_from_name('AssertNilTest'))
+  end
+
+  def test_does_not_resolve_constants_that_are_not_cops
+    assert_nil(derive_cop_class_from_name('CustomCopsTest'))
+  end
+end
+
+class RuboCopTestCaseUnresolvableCopTest < RuboCop::TestCase
+  def test_raises_helpful_error_when_cop_class_cannot_be_derived
+    error = assert_raises(RuntimeError) { cop }
+
+    assert_includes(error.message, 'Define a `cop_class` method in your test class')
+  end
+end
+
+class RuboCopTestCaseConfigurationTest < RuboCop::TestCase
+  def test_assigning_cop_config_configures_the_cop
+    self.cop_config = { 'Max' => 1 }
+
+    assert_equal(1, cop.cop_config['Max'])
+  end
+
+  def test_assigning_cop_config_resets_the_memoized_cop
+    assert_equal(3, cop.cop_config['Max'])
+
+    self.cop_config = { 'Max' => 1 }
+
+    assert_equal(1, cop.cop_config['Max'])
+  end
+
+  def test_default_configuration_is_merged_into_cop_config
+    assert_equal(3, cop.cop_config['Max'])
+  end
+
+  private
+
+  def cop_class
+    RuboCop::Cop::Minitest::MultipleAssertions
+  end
+end
+
+class RuboCopTestCaseTargetRubyVersionTest < RuboCop::TestCase
+  def test_target_ruby_version_flows_into_parser_and_configuration
+    processed_source = parse_source!('bar')
+
+    assert_in_delta(3.4, processed_source.ruby_version)
+    assert_in_delta(3.4, configuration.target_ruby_version)
+  end
+
+  private
+
+  def cop_class
+    CustomCops::UseFoo
+  end
+
+  def target_ruby_version
+    3.4
+  end
+end
+
+# Assigning `target_ruby_version` per test is safe under multithreaded
+# parallel execution because all state lives in the per-test instance.
+# Ruby 3.3 and 3.4 are used here because Prism supports parsing Ruby 3.3+.
+class RuboCopTestCaseParallelExecutionTest < RuboCop::TestCase
+  parallelize_me!
+
+  (1..4).each do |i|
+    define_method(:"test_parses_with_ruby33_variant#{i}") do
+      self.target_ruby_version = 3.3
+
+      processed_source = parse_source!('bar')
+
+      assert_in_delta(3.3, processed_source.ruby_version)
+      assert_in_delta(3.3, configuration.target_ruby_version)
+    end
+
+    define_method(:"test_parses_with_ruby34_variant#{i}") do
+      self.target_ruby_version = 3.4
+
+      processed_source = parse_source!('bar')
+
+      assert_in_delta(3.4, processed_source.ruby_version)
+      assert_in_delta(3.4, configuration.target_ruby_version)
+    end
+
+    define_method(:"test_registers_offense_variant#{i}") do
+      self.target_ruby_version = 3.4
+
+      assert_offense(<<~RUBY)
+        bar
+        ^^^ Use `foo` instead of `bar`.
+      RUBY
+    end
+  end
+
+  private
+
+  def cop_class
+    CustomCops::UseFoo
+  end
+end
+
+# Tests targeting different Ruby versions can live in the same test class
+# by assigning `target_ruby_version` per test. Ruby 3.3 and 3.4 are used
+# here because Prism supports parsing Ruby 3.3+.
+class RuboCopTestCasePerTestTargetRubyVersionTest < RuboCop::TestCase
+  def test_parses_with_ruby33
+    self.target_ruby_version = 3.3
+
+    processed_source = parse_source!('bar')
+
+    assert_in_delta(3.3, processed_source.ruby_version)
+    assert_in_delta(3.3, configuration.target_ruby_version)
+  end
+
+  def test_parses_with_ruby34
+    self.target_ruby_version = 3.4
+
+    processed_source = parse_source!('bar')
+
+    assert_in_delta(3.4, processed_source.ruby_version)
+    assert_in_delta(3.4, configuration.target_ruby_version)
+  end
+
+  def test_assigning_target_ruby_version_resets_the_memoized_configuration
+    self.target_ruby_version = 3.3
+
+    assert_in_delta(3.3, configuration.target_ruby_version)
+
+    self.target_ruby_version = 3.4
+
+    assert_in_delta(3.4, configuration.target_ruby_version)
+  end
+
+  private
+
+  def cop_class
+    CustomCops::UseFoo
+  end
+end


### PR DESCRIPTION
This gem has provided `assert_offense` and friends for custom cop development since v0.15, but only as a mixin into `Minitest::Test`. Some helpers such as `inspect_source` required passing the cop instance explicitly, and there was no natural way to specify the cop configuration or the target Ruby version.

Introduce `RuboCop::TestCase`, a base test case class named in the same manner as `ActiveSupport::TestCase`, as the stable public API:

- The cop under test is derived from the test class name (e.g. `CustomCops::MyCopTest` resolves `CustomCops::MyCop`, then `RuboCop::Cop::Minitest::MyCop`) and can be specified explicitly by defining a `cop_class` method.
- `inspect_source(source, file = nil)` and `investigate(processed_source)` no longer take a cop argument; they use the cop under test. (Breaking)
- `cop_config`, `other_cops`, and `target_ruby_version` can be overridden in the test class, mirroring the RSpec `let` based configuration of rubocop/rubocop specs in a way that is natural for Minitest. Assigning them in a test method changes them for that test only, so tests targeting different Ruby versions can live in the same test class. `target_ruby_version` flows into both the parser and `AllCops: TargetRubyVersion`. All of this state lives in the per-test instance and the one-time plugin integration is guarded by a mutex, so the assertions are safe under multithreaded parallel execution such as `parallelize_me!`.
- The configuration merges the default configuration of the cop under test, integrating lint_roller plugin defaults, in parity with the RSpec `config` shared context of rubocop/rubocop.

The existing mixin into `Minitest::Test` via `require 'rubocop/minitest/support'` is kept for backward compatibility.

Since the cop and its configuration are now built lazily per test instance, this also removes the hand-built `@cop` hacks from this gem's own tests and unskips the tests that were marked flaky because of the shared `@cop` state. The todo generation test is rewritten against the `RuboCop::ExcludeLimit` tmp file tracking API, which replaced `config_to_allow_offenses[:exclude_limit]` in RuboCop core.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
