### PR TITLE
Suppress uninitialized instance variable warnings in the test support

### DIFF
--- a/lib/rubocop/minitest/assert_offense.rb
+++ b/lib/rubocop/minitest/assert_offense.rb
@@ -128,6 +128,9 @@ module RuboCop
       PLUGIN_INTEGRATION_MUTEX = Mutex.new
       private_constant :PLUGIN_INTEGRATION_MUTEX
 
+      # Initialized here so that reading it under `ruby -w` does not warn before the first assignment.
+      @integrated_plugins = nil
+
       class << self
         # Makes the default configuration of extensions registered as lint_roller plugins visible
         # through `RuboCop::ConfigLoader.default_configuration`.
@@ -348,7 +351,7 @@ module RuboCop
       end
 
       def cop_config
-        @cop_config || {}
+        @cop_config ||= {}
       end
 
       def cop_config=(config)
@@ -358,7 +361,7 @@ module RuboCop
       end
 
       def other_cops
-        @other_cops || {}
+        @other_cops ||= {}
       end
 
       def other_cops=(other_cops)
@@ -378,7 +381,7 @@ module RuboCop
 
       def target_ruby_version
         # Prism is the default backend parser for Ruby 3.4+.
-        @target_ruby_version || (ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : RuboCop::TargetRuby::DEFAULT_VERSION)
+        @target_ruby_version ||= (ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : RuboCop::TargetRuby::DEFAULT_VERSION)
       end
 
       def target_ruby_version=(version)


### PR DESCRIPTION
`bundle exec rake` runs the tests with `ruby -w`, and on Ruby 2.7 reading an instance variable before it is assigned emits `warning: instance variable ... not initialized`. `RuboCop::TestCase` and the `assert_offense` mixin read `@integrated_plugins`, `@cop_config`, `@other_cops`, and `@target_ruby_version` lazily, so thousands of these warnings were printed during the test run. Ruby 3.0 removed the warning, so only the Ruby 2.7 runs were affected.

Read the memoized defaults with `||=` and initialize `@integrated_plugins` up front so the reads no longer warn. Behavior is unchanged, and `bundle exec rake` now runs without these warnings.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
