### PR TITLE
Fix `Minitest/MultipleAssertions` todo test on the oldest supported RuboCop

### DIFF
--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -364,6 +364,10 @@ class MultipleAssertionsTest < RuboCop::TestCase
         RuboCop::ExcludeLimit.tmp_dir = nil
       end
     else
+      # Unlike `assert_offense`, `inspect_source` does not reset the globally tracked `config_to_allow_offenses`,
+      # so reset it here to keep a preceding test's higher `Max` from leaking into this assertion.
+      setup_assertion
+
       inspect_source(source, 'test/foo_test.rb')
 
       assert_equal({ 'Max' => 4 }, cop.config_to_allow_offenses[:exclude_limit])


### PR DESCRIPTION
`MultipleAssertionsTest#test_generates_a_todo_based_on_the_worst_violation` failed on the "Check the oldest supported RuboCop version" CI job (RuboCop 1.75.0) with `Expected: {"Max"=>4}` / `Actual: {"Max"=>5}`.

On RuboCop < 1.86.2 the test reads the exclude limit through `cop.config_to_allow_offenses[:exclude_limit]`, which is backed by the globally tracked `RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses`. The `exclude_limit` accumulates with `[current_max, value].max`, and unlike `assert_offense`, `inspect_source` does not reset that global state. When a preceding test left a higher `Max` (for example the `[5/1]` case), it leaked into this assertion, making the `else` branch order-dependent.
On RuboCop >= 1.86.2 the `RuboCop::ExcludeLimit.tmp_dir` branch reads an isolated tmp file, so only the oldest-RuboCop job was affected.

Reset the global state via `setup_assertion` before `inspect_source` so the assertion measures only the source under test.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
