### PR TITLE
Optimize `MultipleAssertions` cop

### DIFF
--- a/changelog/change_improve_multiple_assertions_performance.md
+++ b/changelog/change_improve_multiple_assertions_performance.md
@@ -1,0 +1,1 @@
+* [#363](https://github.com/rubocop/rubocop-minitest/pull/363): Improve `Minitest/MultipleAssertions` performance by removing per-node allocations and a linear matcher-method lookup from the assertion counter. ([@moberegger][])

--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -67,10 +67,15 @@ module RuboCop
             assertions_count(node.body) + assertions_count_in_branches(node.branches)
           when :block, :numblock, :itblock
             assertions_count(node.body)
-          when *RuboCop::AST::Node::ASSIGNMENTS
-            assertions_count_in_assignment(node)
           else
-            node.each_child_node.sum { |child| assertions_count(child) }
+            # Splatting the `ASSIGNMENTS` Set into a `when` makes every other node pay a linear scan.
+            # Collapse it into the `case` once the gemspec floor is Ruby 3.1+, which supports `Set#===`.
+            return assertions_count_in_assignment(node) if RuboCop::AST::Node::ASSIGNMENTS.include?(node.type)
+
+            # `each_child_node` without a block allocates an Enumerator per node.
+            total = 0
+            node.each_child_node { |child| total += assertions_count(child) }
+            total
           end
         end
 

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -23,7 +23,7 @@ module RuboCop
         must_output must_pattern_match must_raise must_be_silent must_throw wont_pattern_match
       ].freeze
 
-      MATCHER_METHODS = VALUE_MATCHERS + BLOCK_MATCHERS
+      MATCHER_METHODS = (VALUE_MATCHERS + BLOCK_MATCHERS).to_set.freeze
 
       ASSERTION_PREFIXES = %i[assert refute].freeze
 


### PR DESCRIPTION
I'm trying to trim down my Rubocop run times in a rather large project. The `Minitest/MultipleAssertions` came up as one of most expensive ones in our profiles. It took 6.74 seconds across  4,261 calls (about 1.6 ms per call).

There are three optimizations in this PR:
- Makes `MATCHER_METHODS` a `Set`. This makes the `MATCHER_METHODS.include?` call in `assertion_method?` an O(1) operation. There are other cops using this helper method, so this may improve performance of those, too.
- Moves the `when *RuboCop::AST::Node::ASSIGNMENTS` to be an inline `RuboCop::AST::Node::ASSIGNMENTS.include?(node.type)` in the fallback branch of `assertions_count_based_on_type`'s `case` expression. `RuboCop::AST::Node::ASSIGNMENTS` is a `Set`, and splatting it turns it into an `Array`, which causes any node that falls through to do an O(n) lookup. The proposed optimization keeps it O(n)
- In the same branch, perform a manual tally instead of using `node.each_child_node.sum`. The latter results in an `Enumerator` being allocated for each node, which slows things down. Doing a manual tally saves on the allocations.

I've included a benchmark below with each proposed change run in isolation, and a final one with all three changes applied. 15 passes were done, with each pass being 600 cop executions. Every version registered 7,200 offenses.

| version                      | mean   | min    | max    | vs original |
|------------------------------|--------|--------|--------|-------------|
| original                     | 0.929s | 0.911s | 0.945s | 1.00x       |
| MATCHER_METHODS as a Set     | 0.842s | 0.826s | 0.880s | 1.10x       |
| ASSIGNMENTS out of `when`    | 0.831s | 0.807s | 0.873s | 1.12x       |
| each_child_node with a block | 0.811s | 0.790s | 0.845s | 1.15x       |
| all three                    | 0.621s | 0.595s | 0.660s | 1.50x       |

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
