### PR TITLE
Optimize `MinitestExplorationHelpers#test_cases` helper

### DIFF
--- a/changelog/fix_test_block_inside_a_method_definition.md
+++ b/changelog/fix_test_block_inside_a_method_definition.md
@@ -1,0 +1,1 @@
+* [#364](https://github.com/rubocop/rubocop-minitest/pull/364): Fix `Minitest/MultipleAssertions`, `Minitest/NoAssertions`, `Minitest/NoTestCases`, and `Minitest/DuplicateTestRun` treating a `test` or `it` block inside a method definition as a test case. ([@moberegger][])

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -59,9 +59,16 @@ module RuboCop
 
         # Support Active Support's `test 'example' { ... }` method.
         # https://api.rubyonrails.org/classes/ActiveSupport/Testing/Declarative.html
-        test_blocks = class_node.each_descendant(:block).select { |block_node| test_block?(block_node) }
+        test_methods + test_blocks(class_node)
+      end
 
-        test_methods + test_blocks
+      def test_blocks(node, found = [])
+        return found if node.type?(:any_def)
+
+        found << node if node.block_type? && test_block?(node)
+        node.each_child_node { |child| test_blocks(child, found) }
+
+        found
       end
 
       def test_method?(def_node, visibility_check: true)

--- a/test/rubocop/cop/minitest/duplicate_test_run_test.rb
+++ b/test/rubocop/cop/minitest/duplicate_test_run_test.rb
@@ -116,4 +116,19 @@ class DuplicateTestRunTest < RuboCop::TestCase
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_child_only_has_a_block_inside_a_method_definition
+    assert_no_offenses(<<~RUBY)
+      class ParentTest < Minitest::Test
+        def test_parent
+        end
+      end
+
+      class ChildTest < ParentTest
+        def build_matrix(name)
+          it(name) { assert_equal(1, 1) }
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -770,6 +770,19 @@ class MultipleAssertionsTest < RuboCop::TestCase
     RUBY
   end
 
+  def test_does_not_register_offense_for_a_block_inside_a_method_definition
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def with_recorded_fixture(name)
+          test(name) do
+            assert_equal(foo, bar)
+            assert_empty(array)
+          end
+        end
+      end
+    RUBY
+  end
+
   private
 
   def configure_max_assertions(max)

--- a/test/rubocop/cop/minitest/no_assertions_test.rb
+++ b/test/rubocop/cop/minitest/no_assertions_test.rb
@@ -131,4 +131,14 @@ class NoAssertionsTest < RuboCop::TestCase
       end
     RUBY
   end
+
+  def test_register_no_offense_for_a_block_inside_a_method_definition
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def build_matrix(name)
+          it(name) { do_something }
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/no_test_cases_test.rb
+++ b/test/rubocop/cop/minitest/no_test_cases_test.rb
@@ -38,6 +38,29 @@ class NoTestCases < RuboCop::TestCase
     RUBY
   end
 
+  def test_considers_active_support_test_example_generated_at_class_level
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        [1, 2].each do |number|
+          test 'something' do; end
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_the_only_test_example_is_inside_a_method_definition
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test class should have test cases.
+        def build_matrix(cases)
+          cases.each do |name|
+            it(name) { skip }
+          end
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_for_non_test_classes
     assert_no_offenses(<<~RUBY)
       class FooTest


### PR DESCRIPTION
A follow up to #363

Optimizes the `MinitestExplorationHelpers#test_cases` helper. The intent of this helper was to find `test` and `it` class definitions, but this would actually descend into method bodies, which incurs a rather substantial traversal cost. The optimization basically terminates the traversal earlier.

This does _technically_ introduce a change in behavior. The old implementation could result in false positives/negatives where the proposed optimized version does not. For example, with something like

```ruby
class FooTest < Minitest::Test
  def build_matrix(cases)
    cases.each do |name|
      it(name) { skip }
    end
  end
end
```

originally the cop would see `it` and think it's a valid test definition even though it is not. `it` is a class level DSL, and in this case an `it` _instance_ method would be called. I am having trouble thinking of a good example here; I can't imagine this happening too often given that this is not valid syntax (at least as far as the minitest DSL is concerned), but I suppose there is a corner case here where the developer implemented their own `it` instance method helper or whatever that allowed this to run. I mention this mostly for completeness.

Benchmarks below. This was run against 5,000 cop executions per rule. Note that the `Minitest/MultipleAssertions` benchmark ran with the changes in #363 included.

| Cop | Before | After | Speedup | Offenses |
| --- | ---: | ---: | ---: | ---: |
| `Minitest/MultipleAssertions` | 0.326s | 0.256s | 1.27x | 3750 |
| `Minitest/NoAssertions` | 0.255s | 0.190s | 1.34x | 250 |
| `Minitest/NoTestCases` | 0.159s | 0.097s | 1.64x | 0 |
| `Minitest/DuplicateTestRun` | 0.253s | 0.121s | **2.08x** | 250 |
| `Minitest/NonPublicTestMethod` | 0.159s | 0.096s | 1.66x | 250 |

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
